### PR TITLE
Rename the skill to Field Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Bring it any question. It may answer in one paragraph, pull a few instruments in
 
 Every inquiry begins as a **Walk**. A direct answer is a complete and successful result when user-specific context is unlikely to change it. A nontrivial Walk begins by focusing with the user: the agent reflects what seems important and unresolved, asks a few questions that could change the analysis, then alternates bounded instrument readings with user correction. A problem can be small yet context-bound: “keep this light” calls for fewer, sharper questions, not an instant canned fix. No files, mode menu, phase announcement, or setup are required.
 
+## Install
+
+Install the whole repository with the [`skills` CLI](https://github.com/vercel-labs/skills) so the skill and its reference files stay together. It supports Claude Code, Codex, and other agents:
+
+```bash
+npx skills add KyleAMathews/hegelian-dialectic-skill
+```
+
+Add `-g` for a global install. Then invoke the skill in an ordinary question:
+
+```text
+/dialectic Why do I keep putting off this small migration?
+```
+
 ## First time? Take the tutorial
 
 Before bringing a difficult question, try a guided, low-stakes tour of the bench:
@@ -15,6 +29,17 @@ Before bringing a difficult question, try a guided, low-stakes tour of the bench
 ```
 
 The tutorial should explain the lab briefly, offer contrasting exercises, and then follow the same rules as ordinary use: you select each instrument; the agent announces it; the instrument returns a bounded reading; and you decide what the readings mean together.
+
+## Quick examples
+
+- **Off-the-cuff question:** `/dialectic Why do moths fly toward porch lights?` → direct answer, no visible method.
+- **Fact-shaped practical Walk:** `/dialectic How many branches should this fruit bush have?` → clarify the desired form, then search or advise; no files.
+- **Instrument-rich Walk:** `/dialectic My wife and I mean different things by a clean kitchen.` → optional term scan, stake map, and small experiment; no files.
+- **Hostile thesis Walk:** `/dialectic Test this thesis against its strongest opposition.` → focus interview, short context-isolated Monks, and user correction.
+- **Survey:** `/dialectic Compare four family calendar systems over three weeks and let us resume later.` → shared collection plan and durable Survey log.
+- **Expedition:** `/dialectic I want the full Expedition on whether our framework should own deployment.` → committed positions, decomposition, candidate palette, audit, and recursion.
+
+You do not need to choose Walk or Survey up front. Ask for a named instrument directly if you want one: “run a term scan,” “check for a ground condition,” “map this possibility space,” or “stress these positions with Electric Monks.”
 
 If the inquiry later needs systematic collection or durable memory, it becomes a **Survey**. If a stubborn contradiction repays the cost of context-isolated committed agents, structural analysis, validation, and recursion, it becomes an **Expedition**. The existing seven-phase Electric Monk dialectic remains strict; it is no longer the price of entry.
 
@@ -135,39 +160,6 @@ Each phase gate cites an instrument-ledger entry. A phase cannot pass merely bec
 | Expedition              | Promoted control log, round files, wiki, queue, and validation trace |
 
 Promotion distills the conversation so far. It does not rewrite an informal Walk as a scripted interview, and the user should not have to restate material already in the session.
-
-## Example paths
-
-- **Off-the-cuff question:** “Why do moths fly toward porch lights?” → direct answer, no visible method.
-- **Fact-shaped practical Walk:** “How many branches should this fruit bush have?” → reflect the specimen, clarify the desired form, then search or advise; no files.
-- **Instrument-rich Walk:** “My wife and I mean different things by a clean kitchen.” → term scan, stake map, and a one-week experiment; no files.
-- **Hostile thesis Walk:** “Test this thesis against its strongest opposition.” → focus interview, short context-isolated Monks, intermediate reading, then user correction; still no files if persistence is unnecessary.
-- **Survey:** “Compare four family calendar systems over three weeks and let us resume later.” → shared collection plan and durable Survey log.
-- **Expedition:** “Should our open-source framework launch first-party cloud hosting?” → inherited field record, context-isolated committed positions, decomposition, candidate palette, audit, and recursion.
-
-## Installation
-
-The skill needs its reference files, so install the whole repository with the [`skills` CLI](https://github.com/vercel-labs/skills). It supports Claude Code, Codex, and other agents:
-
-```bash
-npx skills add KyleAMathews/hegelian-dialectic-skill
-```
-
-Add `-g` for a global install. Then invoke the `dialectic` skill in an ordinary question:
-
-```text
-/dialectic Why do I keep putting off this small migration?
-```
-
-```text
-/dialectic Help us work out what “clean” means when we say the kitchen is done.
-```
-
-```text
-/dialectic I want the full Expedition on whether our framework should own deployment.
-```
-
-You do not need to choose Walk or Survey up front. Ask for a named instrument directly if you want one: “run a term scan,” “check for a ground condition,” “map this possibility space,” or “stress these positions with Electric Monks.”
 
 ## What the Expedition is for
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ That gives every instrument a counterfactual test:
 
 > Without this operation, what would remain unseen?
 
-A term scan separates meanings that fluent conversation lets slide together. Electric Monks expose consequences that cannot be reached while one reasoner hedges between incompatible beliefs. Blind possibility-space cartography compares a frozen source map with blind model replicates so expected model grooves and source-specific residue become visible. A prompt that merely produces more ideas or saves time may still be useful, but it is a tool rather than an instrument.
+A term scan separates meanings that fluent conversation lets slide together. Electric Monks expose consequences that cannot be reached while one reasoner hedges between incompatible beliefs. Blind possibility-space cartography compares a frozen source map with fresh model probes run across pre-frozen, meaning-preserving prompt variants, so expected model grooves and source-specific residue become visible without trusting temperature alone. A prompt that merely produces more ideas or saves time may still be useful, but it is a tool rather than an instrument.
 
 The lab keeps three roles distinct:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dialectic — a field lab for thinking with AI
+# Field Lab — thinking with AI
 
 _The Electric Monks are named after Douglas Adams' machines built to believe things for you._
 
@@ -11,13 +11,13 @@ Every inquiry begins as a **Walk**. A direct answer is a complete and successful
 Install the whole repository with the [`skills` CLI](https://github.com/vercel-labs/skills) so the skill and its reference files stay together. It supports Claude Code, Codex, and other agents:
 
 ```bash
-npx skills add KyleAMathews/hegelian-dialectic-skill
+npx skills add KyleAMathews/field-lab
 ```
 
 Add `-g` for a global install. Then invoke the skill in an ordinary question:
 
 ```text
-/dialectic Why do I keep putting off this small migration?
+/field-lab Why do I keep putting off this small migration?
 ```
 
 ## First time? Take the tutorial
@@ -25,19 +25,19 @@ Add `-g` for a global install. Then invoke the skill in an ordinary question:
 Before bringing a difficult question, try a guided, low-stakes tour of the bench:
 
 ```text
-/dialectic I want to test the instruments in this field lab. Briefly explain how it works, then give me a few easy, low-stakes exercises for instruments that produce different kinds of readings. Let me choose what to try and guide me through one at a time.
+/field-lab I want to test the instruments in this field lab. Briefly explain how it works, then give me a few easy, low-stakes exercises for instruments that produce different kinds of readings. Let me choose what to try and guide me through one at a time.
 ```
 
 The tutorial should explain the lab briefly, offer contrasting exercises, and then follow the same rules as ordinary use: you select each instrument; the agent announces it; the instrument returns a bounded reading; and you decide what the readings mean together.
 
 ## Quick examples
 
-- **Off-the-cuff question:** `/dialectic Why do moths fly toward porch lights?` → direct answer, no visible method.
-- **Fact-shaped practical Walk:** `/dialectic How many branches should this fruit bush have?` → clarify the desired form, then search or advise; no files.
-- **Instrument-rich Walk:** `/dialectic My wife and I mean different things by a clean kitchen.` → optional term scan, stake map, and small experiment; no files.
-- **Hostile thesis Walk:** `/dialectic Test this thesis against its strongest opposition.` → focus interview, short context-isolated Monks, and user correction.
-- **Survey:** `/dialectic Compare four family calendar systems over three weeks and let us resume later.` → shared collection plan and durable Survey log.
-- **Expedition:** `/dialectic I want the full Expedition on whether our framework should own deployment.` → committed positions, decomposition, candidate palette, audit, and recursion.
+- **Off-the-cuff question:** `/field-lab Why do moths fly toward porch lights?` → direct answer, no visible method.
+- **Fact-shaped practical Walk:** `/field-lab How many branches should this fruit bush have?` → clarify the desired form, then search or advise; no files.
+- **Instrument-rich Walk:** `/field-lab My wife and I mean different things by a clean kitchen.` → optional term scan, stake map, and small experiment; no files.
+- **Hostile thesis Walk:** `/field-lab Test this thesis against its strongest opposition.` → focus interview, short context-isolated Monks, and user correction.
+- **Survey:** `/field-lab Compare four family calendar systems over three weeks and let us resume later.` → shared collection plan and durable Survey log.
+- **Expedition:** `/field-lab I want the full Expedition on whether our framework should own deployment.` → committed positions, decomposition, candidate palette, audit, and recursion.
 
 You do not need to choose Walk or Survey up front. Ask for a named instrument directly if you want one: “run a term scan,” “check for a ground condition,” “map this possibility space,” or “stress these positions with Electric Monks.”
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: dialectic
+name: field-lab
 description: "An always-available field lab for thinking with AI. Use it for any question, from an off-the-cuff factual query or practical problem to a genuine tension, hostile thesis test, high-stakes decision, or full recursive dialectic. Give direct answers when they are enough. For nontrivial inquiry, begin with a camera-mode Walk: interview lightly, offer useful instruments, and run only instruments the user selects. Return bounded readings rather than explaining, synthesizing, or acting beyond what an instrument measures. Promote only when the work needs a systematic Survey or the full Electric Monk Expedition."
 ---
 
-# Dialectic Field Lab
+# Field Lab
 
 Treat every inquiry as field work. Start with the smallest useful feedback loop, carry the whole instrument bench, and add persistence only when it earns its cost.
 

--- a/reference/instrument-contract.md
+++ b/reference/instrument-contract.md
@@ -182,6 +182,8 @@ Use controls in proportion to the cost of being wrong:
 - **Moderate cost:** compare against a neutral baseline, reversed frame, renamed term, or nearby counterexample.
 - **High cost:** add independent evidence or an agent blind to the first readout, then record what remained stable and what moved.
 
+When parallel generative probes sample a possibility space, do not rely on model temperature for diversity. Freeze a small family of meaning-preserving prompt variants before reading any output. Keep the specimen information, criteria, coordinate, and output contract fixed while varying surface wording or order. Label every variant and distinguish recurrence across variants from repetition under one exact prompt. Treat any substantive framing change as a separate stratum, not a replicate.
+
 If a contradiction, axis, or conclusion appears only after a strong perturbation, mark it as possibly induced.
 
 After a run, compare its access differential with its artifact risk. If the reading was already visible before the perturbation, label the run confirmation or convenience. If the perturbation created the output, label it induced or generated rather than discovered. Then complete the caddy gate. Compare the unmeasured remainder with the registry and normally offer three distinct instruments, explaining what each measures and why that reading may help. Offer fewer when fewer honestly fit. When none fits, say that no next instrument is warranted. Never rank or run the choices without user selection, or cross from a bounded reading into explanation, synthesis, recommendation, or action.

--- a/reference/instruments/blind-cartography.md
+++ b/reference/instruments/blind-cartography.md
@@ -18,8 +18,8 @@
 ## Procedure
 
 1. **Freeze the source track.** Build a source-grounded map from observations, evidence, positions, negation, or prior instrument readouts. For a quick scout, this may be a small map produced from the user's specimen or by one source-track agent, but it must be frozen before any expectation output is read. Type every item by provenance. An option invented by the source-track agent from a sparse specimen is a `hypothesis`, not a source-backed fact. The expectation probes must not generate this map. Do not show it to them.
-2. **Plan the sample.** Choose only coordinates that could change the inquiry. Run at least three core replicates with the same neutral prompt. Add a small set of relevant strata, such as actor, scale, time, form, intervention, or constraint. Do not run the full Cartesian product.
-3. **Keep probes blind.** Use fresh contexts. Give each probe only its prompt and coordinate. Do not expose source material, desired answers, atlas labels, or sibling outputs. Record model and sampling controls when known.
+2. **Plan the sample.** Choose only coordinates that could change the inquiry. Before reading any output, freeze a core prompt family: one canonical neutral brief and at least two slight, meaning-preserving variants. Keep the information, criteria, coordinate, and output contract fixed; vary surface wording, clause order, or neutral phrasing. Give at least three fresh probes different members of this family. Temperature or sampling randomness does not replace deliberate prompt variation. If budget permits, add an exact-prompt replicate to estimate within-wording variation, but keep it distinct from cross-variant recurrence. Add a small set of relevant strata, such as actor, scale, time, form, intervention, or constraint. Do not run the full Cartesian product.
+3. **Keep probes blind.** Use fresh contexts. Give each probe only its assigned prompt variant and coordinate. Do not expose source material, desired answers, atlas labels, or sibling outputs. Record the exact variant, model, and sampling controls when known.
 4. **Cluster expected basins.** Group repeated moves, assumptions, mechanisms, examples, consequences, and answer forms. Keep model-specific basins visible when model families differ.
 5. **Overlay the source map.** Mark each source option as a deep groove, local groove, source-specific understory, atlas residual, or collapse risk.
 6. **Re-scan both maps.** Record source-backed versions of expected basins. Then re-scan source material that neither the atlas nor the frozen source map captured; label these atlas-induced residuals without judging their value.
@@ -39,7 +39,7 @@ Return:
 
 Use the map labels consistently:
 
-- **Expected basin:** a semantically recurring move in the blind probes; always report the exact count and sampled coordinates.
+- **Expected basin:** a semantically recurring move in the blind probes; always report the exact count, prompt variants, and sampled coordinates.
 - **Deep groove:** a basin that recurs in the core replicates and across more than one relevant stratum or meaning-preserving prompt form.
 - **Local groove:** a basin confined to one stratum, prompt form, or model family.
 - **Source-specific understory:** a directly supported source-track mechanism or option absent from the sampled expectation map. Agent-generated hypotheses do not earn this label without later support.
@@ -55,9 +55,10 @@ If no independent source track is available, stop or explicitly downgrade the ru
 
 ## Calibration and Controls
 
-- Base any recurrence claim on at least three blind replicates and report exact counts. Fresh contexts reduce leakage but do not make outputs statistically independent, especially within one model family. One probe may only suggest the next sample.
+- Base any recurrence claim on at least three blind probes spanning the frozen prompt family, and report exact counts by prompt variant. Fresh contexts reduce leakage but do not make outputs statistically independent, especially within one model family. Temperature is not evidence of adequate variation. One probe may only suggest the next sample.
 - Keep source and expectation tracks isolated until the source map is frozen.
 - Preserve raw probes and exact visible inputs in a Survey or Expedition.
+- Freeze meaning-preserving variants before exposure. If a variant changes the task, criteria, evidence, or output contract, treat it as a separate stratum rather than a core replicate.
 - Change one sampling variable at a time when possible.
 - Track new-basin yield by batch, replicate disagreement, strata covered, and unsampled cells.
 - When stakes are high, repeat across model families or use an independent factual or historical check.
@@ -66,7 +67,7 @@ If no independent source track is available, stop or explicitly downgrade the ru
 
 - Baseline leakage steers source generation toward the atlas.
 - Shared training and model lineage make probes correlated.
-- Prompt wording creates or hides basins.
+- Identical prompts over-sample one wording path; uncontrolled prompt variation changes the task and creates false diversity.
 - Adaptive sampling distorts initial recurrence counts.
 - The atlas mistakes model reconstructibility for social prevalence.
 - Recurrent basins are promoted into recommendations without source-grounded support.
@@ -84,6 +85,6 @@ If no independent source track is available, stop or explicitly downgrade the ru
 
 ## Cost and Persistence
 
-- **Quick scout:** One small frozen source map plus three fresh core probes; medium agent cost; session-only; directional findings only.
+- **Quick scout:** One small frozen source map plus three fresh core probes using a pre-frozen canonical prompt and two meaning-preserving variants; medium agent cost; session-only; directional findings only.
 - **Atlas:** Usually 6–12 probes plus clustering and overlay; Survey-scale; preserve raw probes, sampling plan, frozen source map, atlas, and overlay.
 - **Expedition use:** Link the atlas to the round control log or frontier ledger. Keep it distinct from Monk belief outputs and validation judgments.


### PR DESCRIPTION
## Summary

- rename the public skill ID and invocation to `field-lab`
- move installation, tutorial, and examples to the top of the README
- calibrate parallel generative probes with frozen meaning-preserving prompt variants instead of relying on temperature

The GitHub repository has also been renamed to `KyleAMathews/field-lab`, and the README install command uses the new URL.

## Validation

- `quick_validate.py` passes
- `git diff --check` passes