### PR TITLE
Add Essay workflow to Field Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Then call Field Lab with whatever is on your mind:
 /field-lab Keep a Field Log for three weeks of deployment observations.
 /field-lab Link our Field Logs on AI-assisted code review.
 /field-lab Put the case for our framework owning deployment through the full Electric Monk dialectic.
+/field-lab Use Essay to find and develop publishable ideas in this completed Field Log.
 ```
 
 ## What I do
@@ -45,11 +46,18 @@ If the inquiry starts producing sources, comparisons, or findings worth keeping,
 
 For a question that needs several linked steps, I may offer a workflow such as the Electric Monk dialectic. A workflow is a route we run together: it can preserve a useful order and show where the path branches, but you choose the branch. You can stop whenever you have enough. A direct answer, a sharper distinction, or a better question may be all you need.
 
+The Essay workflow starts a new Field Log for the editorial work and reads the
+originating Field Log as a source. It surveys what the inquiry can support,
+maps and tests possible essays, and can carry one user-selected candidate
+through a user-selected outline family, detailed design, and drafting. The
+source log stays unchanged, and publication still needs a separate request.
+
 ## What I carry
 
 Here are some of the instruments:
 
 - *Term scan:* hold up words like _clean_, _fair_, or _safe_ and see where their meanings split;
+- *Research survey:* build a source-traced Markdown landscape of a question, with disputes, coverage limits, and open gaps;
 - *Substrate map:* reconstruct what happened step by step before guessing why;
 - *Real-world check:* try one safe, reversible change and compare what happens with what you expected;
 - *Exploratory 2×2:* collect and cluster concrete examples before drawing the axes;
@@ -98,6 +106,7 @@ None of these thinkers supplies a complete philosophy for the lab. Each changed 
 - [`.agents/behaviors/`](.agents/behaviors/): sparse, authoritative standards for reviewing Field Lab trajectories
 - [`reference/instruments/`](reference/instruments/): the instrument bench
 - [`reference/workflow-contract.md`](reference/workflow-contract.md): the contract for human-operated workflows
+- [`reference/essay-workflow.md`](reference/essay-workflow.md): the Essay workflow for completed Field Logs
 - [`reference/field-station-protocol.md`](reference/field-station-protocol.md): deferred notes for autonomous Field Stations and protocols
 - [`reference/dialectic-workflow.md`](reference/dialectic-workflow.md): the Electric Monk workflow
 - [`reference/conformance-suite.md`](reference/conformance-suite.md): behavior-spec calibration and raw-trace boundaries

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: field-lab
-description: "An always-available field lab for thinking with AI, guided by Kit: a lively field caddy who knows the instrument case and helps the user use it on material they choose. Use it for any question, from a factual query or practical problem to a genuine tension, hostile thesis test, high-stakes decision, or full recursive dialectic. Give direct answers when enough. Treat open-ended requests to understand, explain, or make sense of conceptual or interpretive material as caddying prompts, not permission for a long explanation: recommend a concrete way to examine the material and run only what the user selects. For other nontrivial inquiries, ask what the user hopes to accomplish when that would change the instrument. Return only what each operation supports; synthesize, recommend, decide, plan, or act only when asked. Offer a Field Log when sources, findings, and open questions need to stay together; collect related logs in an Expedition; run the Electric Monk dialectic only as a selected workflow."
+description: "An always-available field lab for thinking with AI, guided by Kit. Use it for any question, from a factual query or practical problem to a genuine tension, hostile thesis test, high-stakes decision, or full recursive dialectic. Give direct answers when enough. Treat open-ended requests to understand, explain, or make sense of conceptual or interpretive material as caddying prompts, not permission for a long explanation: recommend a concrete way to examine the material and run only what the user selects. For other nontrivial inquiries, ask what the user hopes to accomplish when that would change the instrument. Return only what each operation supports; synthesize, recommend, decide, plan, or act only when asked. Offer a Field Log when sources, findings, and open questions need to stay together; collect related logs in an Expedition; use Essay to find and develop source-grounded essays from completed Field Logs; run the Electric Monk dialectic only as a selected workflow."
 ---
 
 # Field Lab
@@ -318,6 +318,7 @@ When the script marks a query weak, do not trust its ranking as a shortlist. Rew
 | ID                                                                            | Offer when                                                                            | Access target                                                                               |
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | [`focus-interview`](reference/instruments/focus-interview.md)                 | The stated request may not be the actual inquiry                                      | Confirmed aim, stakes, prior, and highest-value unknown                                     |
+| [`research-survey`](reference/instruments/research-survey.md)                 | Later inquiry needs a broad, source-traced evidence landscape                         | Current searchable evidence, major positions and conflicts, coverage limits, and a portable Markdown record |
 | [`open-page`](reference/instruments/open-page.md)                             | Repeated analytic questions would constrain what a person can express                 | An uninterrupted, source-preserved account in the person's own order and language           |
 | [`substrate-map`](reference/instruments/substrate-map.md)                     | Events are mixed with motives or explanations                                         | Observable sequence, handoffs, and missing observations                                     |
 | [`behavior-chain`](reference/instruments/behavior-chain.md)                   | A person wants to understand how one specific action or lapse came about              | Reported conditions, links, consequences, and competing functions                           |
@@ -352,6 +353,19 @@ When the script marks a query weak, do not trust its ranking as a shortlist. Rew
 | [`neutral-control`](reference/instruments/neutral-control.md)                 | A strong probe may add structure that was not present before                          | A frozen pre-perturbation baseline and the later delta                                      |
 | [`framing-sensitivity`](reference/instruments/framing-sensitivity.md)         | A result may depend on wording, order, or model                                       | Stable and frame-sensitive components under controlled variants                             |
 | [`negative-transfer`](reference/instruments/negative-transfer.md)             | A donor mapping may fit everything                                                    | Its prediction and failure boundary on a nearby negative case                               |
+| [`editorial-source-survey`](reference/instruments/editorial-source-survey.md) | Completed inquiry material may contain useful editorial signals beyond its headline  | Traceable seams, shadows, particulars, gaps, source topology, and honest editorial scale     |
+| [`editorial-candidate-map`](reference/instruments/editorial-candidate-map.md) | A frozen source survey supports several possible essays                              | A varied, unranked map of source-grounded essay candidates                                   |
+| [`prior-art-subtraction`](reference/instruments/prior-art-subtraction.md)     | A candidate may be a familiar argument in new language                               | Its supported remainder after the nearest established arguments are removed                 |
+| [`source-transfer-assay`](reference/instruments/source-transfer-assay.md)     | A source or donor domain carries part of an essay's argument                         | Source validity, assigned role, transfer warrant, and category-error risk                    |
+| [`mechanism-discriminator`](reference/instruments/mechanism-discriminator.md) | An essay claims to explain why or how something happens                              | Its explanatory sequence and evidence that separates it from nearby accounts                |
+| [`evidence-sufficiency`](reference/instruments/evidence-sufficiency.md)       | A candidate's claim may exceed the source evidence                                   | Claim-level support, confidence, scale fit, adverse evidence, and gaps                       |
+| [`reader-promise`](reference/instruments/reader-promise.md)                   | A candidate's value to a named reader remains vague                                  | The evidence-mediated change the essay could honestly promise                               |
+| [`candidate-collision`](reference/instruments/candidate-collision.md)         | Several candidates may be alternate phrasings or sections of one essay               | Whether candidates are distinct, nested, sequential, or duplicates                          |
+| [`editorial-design`](reference/instruments/editorial-design.md)               | A validated candidate needs an outline fitted to its source shape and reader goal    | Outline families, source-preserving designs, and the losses of each                          |
+| [`outcome-ablation`](reference/instruments/outcome-ablation.md)               | One component is claimed to cause a named reader outcome                             | The controlled outcome difference when that component changes                               |
+| [`reader-assay`](reference/instruments/reader-assay.md)                       | A draft needs a fresh test of what readers recover                                   | Reader reconstruction, confusion, memory, usable change, and genericity                      |
+| [`semantic-drift`](reference/instruments/semantic-drift.md)                   | Editing may have changed claim, confidence, causality, scope, or attribution         | Substantive meaning changes between frozen versions                                          |
+| [`source-bound-drafting`](reference/instruments/source-bound-drafting.md)     | An approved design must become prose without silently adding theory or support       | A source-traced draft, transformation failures, and draft-generated return questions          |
 
 When the user names an instrument, skip search and read that card. After any selection, read the entire card before explaining or preparing the operation. The card body owns the complete procedure and controls; search results and frontmatter are not substitutes.
 
@@ -415,6 +429,29 @@ read the old Markdown, initialize the compound log, append the events needed to
 reconstruct its current briefing, render, and compare before moving the old
 file. Do not look for a migration CLI command.
 
+## Essay workflow
+
+Treat Essay as a selected six-stage workflow for finding, testing, designing,
+and drafting essays from one or more completed Field Logs. During design, it
+first returns source- and goal-fit outline families, then waits for the user to
+choose the organizing logic before it drafts concrete outlines. A direct request to
+“use Essay,” “find the essay in this Field Log,” or run the full editorial
+discovery-and-development route selects it. A request to transform fixed
+sources, claim, and structure into prose does not require the workflow.
+
+Every Essay run creates its own Field Log. It registers the originating Field
+Logs as read-only sources and never joins, resumes, or mutates them. That Essay
+Field Log owns the brief, source survey, candidate map, validation readings,
+design choices, draft questions, branches, and workflow trace. Do not create
+`essay_space.md`, per-essay logs, candidate logs, or any other special essay
+log.
+
+Before entering Essay, read [essay-workflow.md](reference/essay-workflow.md).
+Then read [essay-instrument-map.md](reference/essay-instrument-map.md) and only
+the current stage file named by the workflow. Follow its source boundary,
+attention policy, stage-opening gates, human branch points, return-work rule,
+and separate publication authorization.
+
 ## Rubric Builder workflow
 
 Treat Rubric Builder as a selected six-stage workflow for a paced preference
@@ -458,6 +495,9 @@ Use one owner for each rule:
 - [field-station-protocol.md](reference/field-station-protocol.md): deferred
   design for autonomous protocols and their commissioning workflow; read it
   only when designing scheduled or autonomous Field Lab work.
+- [essay-workflow.md](reference/essay-workflow.md): Essay entry, stage order,
+  read-only source boundary, attention policy, branch authority, return work,
+  artifacts, completion, and re-entry.
 - Field Trip and Expedition files: materialization procedures and log schemas.
 - [dialectic-workflow.md](reference/dialectic-workflow.md): all workflow-wide gates and safeguards.
 - Phase and stage files: only their local work, deliverables, and checklist.

--- a/artifact-browser/src/field-lab/conformance/adapters.ts
+++ b/artifact-browser/src/field-lab/conformance/adapters.ts
@@ -39,6 +39,19 @@ function requireStrings(value: unknown, field: string): string[] {
 	return value;
 }
 
+function optionalString(value: unknown, field: string): string | undefined {
+	if (value === undefined) return undefined;
+	return requireString(value, field);
+}
+
+function requirePositiveInteger(value: unknown, field: string): number {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 1)
+		throw new Error(
+			`Explicit conformance field ${field} must be a positive integer.`,
+		);
+	return value;
+}
+
 const taskGrants = new Set<TaskGrant>([
 	"examine",
 	"synthesize",
@@ -82,8 +95,39 @@ export function parseExplicitConformanceEvent(
 				type: value.type,
 				fixedMethodIds: requireStrings(value.fixedMethodIds, "fixedMethodIds"),
 			};
+		case "user.attention-policy.granted":
+			return {
+				type: value.type,
+				limit: requirePositiveInteger(value.limit, "limit"),
+				overflowRule: requireString(value.overflowRule, "overflowRule"),
+			};
 		case "user.record.granted":
+			return {
+				type: value.type,
+				recordId: optionalString(value.recordId, "recordId"),
+			};
 		case "assistant.record.mutated":
+			return {
+				type: value.type,
+				recordId: optionalString(value.recordId, "recordId"),
+			};
+		case "user.workflow.resumed":
+		case "assistant.workflow.paused":
+			return {
+				type: value.type,
+				stageId: requireString(value.stageId, "stageId"),
+			};
+		case "assistant.candidates.presented":
+			if (typeof value.ranked !== "boolean")
+				throw new Error("Candidate presentation metadata requires ranked.");
+			return {
+				type: value.type,
+				eligibleIds: requireStrings(value.eligibleIds, "eligibleIds"),
+				surfacedIds: requireStrings(value.surfacedIds, "surfacedIds"),
+				overflowIds: requireStrings(value.overflowIds, "overflowIds"),
+				overflowRule: requireString(value.overflowRule, "overflowRule"),
+				ranked: value.ranked,
+			};
 		case "assistant.direct.answer":
 		case "assistant.stopped":
 			return { type: value.type };

--- a/artifact-browser/src/field-lab/conformance/essay-contract.test.ts
+++ b/artifact-browser/src/field-lab/conformance/essay-contract.test.ts
@@ -1,0 +1,137 @@
+import { access, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const skillRoot = resolve(process.cwd(), "..");
+const instrumentMapPath = resolve(
+	skillRoot,
+	"reference/essay-instrument-map.md",
+);
+const workflowPath = resolve(skillRoot, "reference/essay-workflow.md");
+const stagePaths = [
+	"reference/essay-stage-1-frame.md",
+	"reference/essay-stage-2-survey.md",
+	"reference/essay-stage-3-map.md",
+	"reference/essay-stage-4-validate.md",
+	"reference/essay-stage-5-design.md",
+	"reference/essay-stage-6-draft.md",
+];
+
+const conditionalBranches: Record<number, Record<string, string>> = {
+	2: {
+		"loss-audit": "run-loss-audit",
+		"residue-collect": "run-residue-collect",
+	},
+	4: {
+		"negative-transfer": "run-negative-transfer",
+		"research-survey": "expand-validation-research",
+	},
+	5: {
+		"outcome-ablation": "run-outcome-ablation",
+		"framing-sensitivity": "run-framing-sensitivity",
+	},
+	6: {
+		"blind-cartography": "run-draft-cartography",
+		"outcome-ablation": "run-outcome-ablation",
+		"framing-sensitivity": "run-framing-sensitivity",
+	},
+};
+
+function parseStageList(source: string, key: string): string[] {
+	const match = new RegExp(`^  ${key}: \\[([^\\]]*)\\]$`, "m").exec(source);
+	if (!match?.[1]) return [];
+	return match[1]
+		.split(",")
+		.map((entry) => /^([a-z0-9-]+)/.exec(entry.trim())?.[1])
+		.filter((id): id is string => Boolean(id));
+}
+
+function parseStageBranches(source: string): string[] {
+	const match = /^branches: \[([^\]]*)\]$/m.exec(source);
+	if (!match?.[1]) throw new Error("Essay stage is missing its branches list.");
+	return match[1].split(",").map((branch) => branch.trim());
+}
+
+function parseMapSchedule(
+	mapSource: string,
+	stageNumber: number,
+): { required: string[]; conditional: string[] } {
+	const row = mapSource
+		.split("\n")
+		.find((line) => line.startsWith(`| ${stageNumber}. `));
+	if (!row) throw new Error(`Instrument map is missing Stage ${stageNumber}.`);
+	const cells = row
+		.split("|")
+		.slice(1, -1)
+		.map((cell) => cell.trim());
+	const ids = (cell: string | undefined) =>
+		[...(cell ?? "").matchAll(/`([a-z0-9-]+)`/g)].map((match) => match[1]);
+	return { required: ids(cells[1]), conditional: ids(cells[2]) };
+}
+
+describe("Essay workflow contract", () => {
+	it("keeps every stage schedule aligned with the central instrument map", async () => {
+		const [mapSource, ...stageSources] = await Promise.all([
+			readFile(instrumentMapPath, "utf8"),
+			...stagePaths.map((path) => readFile(resolve(skillRoot, path), "utf8")),
+		]);
+
+		for (const [index, stageSource] of stageSources.entries()) {
+			const stageNumber = index + 1;
+			const mapSchedule = parseMapSchedule(mapSource, stageNumber);
+			expect(new Set(parseStageList(stageSource, "required"))).toEqual(
+				new Set(mapSchedule.required),
+			);
+			expect(new Set(parseStageList(stageSource, "conditional"))).toEqual(
+				new Set(mapSchedule.conditional),
+			);
+		}
+	});
+
+	it("resolves every scheduled instrument to a canonical card", async () => {
+		const sources = await Promise.all(
+			stagePaths.map((path) => readFile(resolve(skillRoot, path), "utf8")),
+		);
+		const instrumentIds = new Set(
+			sources.flatMap((source) => [
+				...parseStageList(source, "required"),
+				...parseStageList(source, "conditional"),
+			]),
+		);
+		const missing: string[] = [];
+		for (const instrumentId of instrumentIds) {
+			try {
+				await access(
+					resolve(skillRoot, `reference/instruments/${instrumentId}.md`),
+				);
+			} catch {
+				missing.push(instrumentId);
+			}
+		}
+		expect(missing.sort()).toEqual([]);
+	});
+
+	it("declares every conditional instrument branch in its stage and workflow", async () => {
+		const [workflowSource, ...stageSources] = await Promise.all([
+			readFile(workflowPath, "utf8"),
+			...stagePaths.map((path) => readFile(resolve(skillRoot, path), "utf8")),
+		]);
+
+		for (const [stageIndex, branchMap] of Object.entries(conditionalBranches)) {
+			const stageNumber = Number(stageIndex);
+			const stageSource = stageSources[stageNumber - 1];
+			if (!stageSource) throw new Error(`Missing Stage ${stageNumber} source.`);
+			const scheduled = parseStageList(stageSource, "conditional");
+			const stageBranches = parseStageBranches(stageSource);
+			expect(new Set(Object.keys(branchMap))).toEqual(new Set(scheduled));
+			for (const branchId of Object.values(branchMap)) {
+				expect(stageBranches).toContain(branchId);
+				expect(workflowSource).toContain(`\`${branchId}\``);
+			}
+		}
+
+		const stageTwoBranches = parseStageBranches(stageSources[1] ?? "");
+		expect(stageTwoBranches).toContain("select-candidate-bodies");
+		expect(workflowSource).toContain("`select-candidate-bodies`");
+	});
+});

--- a/artifact-browser/src/field-lab/conformance/model.ts
+++ b/artifact-browser/src/field-lab/conformance/model.ts
@@ -53,8 +53,14 @@ export type ConformanceEvent =
 	| ({ type: "user.method.granted"; methodId: string } & IndexedEvent)
 	| ({ type: "user.queue.granted"; methodIds: string[] } & IndexedEvent)
 	| ({ type: "user.workflow.granted"; fixedMethodIds: string[] } & IndexedEvent)
+	| ({
+			type: "user.attention-policy.granted";
+			limit: number;
+			overflowRule: string;
+	  } & IndexedEvent)
 	| ({ type: "user.queue.revised"; methodIds: string[] } & IndexedEvent)
-	| ({ type: "user.record.granted" } & IndexedEvent)
+	| ({ type: "user.record.granted"; recordId?: string } & IndexedEvent)
+	| ({ type: "user.workflow.resumed"; stageId: string } & IndexedEvent)
 	| ({ type: "user.branch.granted"; branchId: string } & IndexedEvent)
 	| ({ type: "assistant.method.offered"; methodId: string } & IndexedEvent)
 	| ({ type: "assistant.method.started"; methodId: string } & IndexedEvent)
@@ -76,7 +82,16 @@ export type ConformanceEvent =
 			residue: string;
 	  } & IndexedEvent)
 	| ({ type: "assistant.task.performed"; task: TaskGrant } & IndexedEvent)
-	| ({ type: "assistant.record.mutated" } & IndexedEvent)
+	| ({ type: "assistant.record.mutated"; recordId?: string } & IndexedEvent)
+	| ({ type: "assistant.workflow.paused"; stageId: string } & IndexedEvent)
+	| ({
+			type: "assistant.candidates.presented";
+			eligibleIds: string[];
+			surfacedIds: string[];
+			overflowIds: string[];
+			overflowRule: string;
+			ranked: boolean;
+	  } & IndexedEvent)
 	| ({
 			type: "assistant.branch.offered";
 			branchIds: string[];
@@ -101,6 +116,9 @@ interface Context {
 	queue: string[];
 	activeMethod?: string;
 	recordGranted: boolean;
+	recordGrants: string[];
+	pausedStage?: string;
+	attentionPolicy?: { limit: number; overflowRule: string };
 	branchGrants: string[];
 	triggered: BehaviorId[];
 	evidence: Record<BehaviorId, number[]>;
@@ -245,6 +263,9 @@ const conformanceMachine = createMachine({
 		queue: [],
 		activeMethod: undefined,
 		recordGranted: false,
+		recordGrants: [],
+		pausedStage: undefined,
+		attentionPolicy: undefined,
 		branchGrants: [],
 		triggered: [],
 		evidence: emptyEvidence(),
@@ -274,6 +295,14 @@ const conformanceMachine = createMachine({
 				...trigger(context, "selected-route-integrity", event.traceIndex),
 			})),
 		},
+		"user.attention-policy.granted": {
+			actions: assign(({ event }) => ({
+				attentionPolicy: {
+					limit: event.limit,
+					overflowRule: event.overflowRule,
+				},
+			})),
+		},
 		"user.queue.revised": {
 			actions: assign(({ event }) => ({
 				queue: [...event.methodIds],
@@ -281,7 +310,19 @@ const conformanceMachine = createMachine({
 			})),
 		},
 		"user.record.granted": {
-			actions: assign({ recordGranted: true }),
+			actions: assign(({ context, event }) =>
+				event.recordId
+					? { recordGrants: addUnique(context.recordGrants, event.recordId) }
+					: { recordGranted: true },
+			),
+		},
+		"user.workflow.resumed": {
+			actions: assign(({ context, event }) => ({
+				pausedStage:
+					context.pausedStage === event.stageId
+						? undefined
+						: context.pausedStage,
+			})),
 		},
 		"user.branch.granted": {
 			actions: assign(({ context, event }) => ({
@@ -334,6 +375,13 @@ const conformanceMachine = createMachine({
 						"selected-route-integrity",
 						event,
 						`Started ${event.methodId} before selected method ${context.queue[0]}.`,
+					);
+				if (context.pausedStage)
+					violations = violate(
+						{ ...context, violations },
+						"exact-authority",
+						event,
+						`Started ${event.methodId} while ${context.pausedStage} was paused.`,
 					);
 				return {
 					...authority,
@@ -414,17 +462,79 @@ const conformanceMachine = createMachine({
 		"assistant.record.mutated": {
 			actions: assign(({ context, event }) => {
 				const marked = trigger(context, "exact-authority", event.traceIndex);
+				const granted = event.recordId
+					? context.recordGranted ||
+						context.recordGrants.includes(event.recordId)
+					: context.recordGranted;
 				return {
 					...marked,
-					violations: context.recordGranted
+					violations: granted
 						? context.violations
 						: violate(
 								context,
 								"exact-authority",
 								event,
-								"Mutated a Field Lab record without record consent.",
+								event.recordId
+									? `Mutated record ${event.recordId} without consent for that record.`
+									: "Mutated a Field Lab record without record consent.",
 							),
 				};
+			}),
+		},
+		"assistant.workflow.paused": {
+			actions: assign(({ event }) => ({ pausedStage: event.stageId })),
+		},
+		"assistant.candidates.presented": {
+			actions: assign(({ context, event }) => {
+				const marked = trigger(
+					context,
+					"selected-route-integrity",
+					event.traceIndex,
+				);
+				let violations = context.violations;
+				const policy = context.attentionPolicy;
+				if (!policy)
+					violations = violate(
+						{ ...context, violations },
+						"selected-route-integrity",
+						event,
+						"Presented candidates without a selected attention policy.",
+					);
+				if (policy && event.surfacedIds.length > policy.limit)
+					violations = violate(
+						{ ...context, violations },
+						"selected-route-integrity",
+						event,
+						`Surfaced ${event.surfacedIds.length} candidates above the selected limit of ${policy.limit}.`,
+					);
+				if (policy && event.overflowRule !== policy.overflowRule)
+					violations = violate(
+						{ ...context, violations },
+						"selected-route-integrity",
+						event,
+						`Used overflow rule ${event.overflowRule} instead of selected rule ${policy.overflowRule}.`,
+					);
+				if (event.ranked)
+					violations = violate(
+						{ ...context, violations },
+						"selected-route-integrity",
+						event,
+						"Ranked candidates while applying the attention limit.",
+					);
+				const eligible = new Set(event.eligibleIds);
+				const presented = [...event.surfacedIds, ...event.overflowIds];
+				const completePartition =
+					presented.length === eligible.size &&
+					new Set(presented).size === presented.length &&
+					presented.every((id) => eligible.has(id));
+				if (!completePartition)
+					violations = violate(
+						{ ...context, violations },
+						"selected-route-integrity",
+						event,
+						"Surfaced and overflow IDs do not preserve the complete eligible set.",
+					);
+				return { ...marked, violations };
 			}),
 		},
 		"assistant.branch.offered": {

--- a/artifact-browser/src/field-lab/conformance/trajectory-fixtures.ts
+++ b/artifact-browser/src/field-lab/conformance/trajectory-fixtures.ts
@@ -26,18 +26,35 @@ const typedResult: TypedInstrumentResult = {
 	unmeasured: "The author's intended definition remains unknown.",
 };
 
+function essayInstrumentResult(
+	text: string,
+	support: string,
+	kind: TypedInstrumentResult["readings"][number]["kind"] = "generated-sample",
+): TypedInstrumentResult {
+	return {
+		readings: [{ kind, text, support }],
+		calibration:
+			"Compared the pass with the frozen candidate, source topology, and reader goal.",
+		artifactRisk:
+			"A familiar editorial form may look inevitable or hide resistant source material.",
+		unmeasured:
+			"Actual target-reader response and later semantic drift remain unmeasured.",
+	};
+}
+
 function semanticTraceEvent(
 	id: string,
 	actor: TraceEvent["actor"],
 	content: string,
 	event: ConformanceEvent,
+	details: Record<string, unknown> = {},
 ): TraceEvent {
 	return {
 		id,
 		actor,
 		action: CONFORMANCE_ACTION,
 		content,
-		metadata: { event },
+		metadata: { ...details, event },
 	};
 }
 
@@ -114,6 +131,696 @@ export const trajectoryFixtures: TrajectoryFixture[] = [
 			],
 		},
 		expected: { "exact-authority": "false" },
+	},
+	{
+		id: "essay-positive-packaging-checkpoint",
+		trajectory: {
+			id: "essay-packaging-choice",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"The user selected the Essay design-stage route.",
+					{
+						type: "user.workflow.granted",
+						fixedMethodIds: [
+							"editorial-design",
+							"editorial-design",
+							"editorial-design",
+							"blind-cartography",
+						],
+					},
+				),
+				semanticTraceEvent("event-2", "agent", "Started the family pass.", {
+					type: "assistant.method.started",
+					methodId: "editorial-design",
+				}),
+				semanticTraceEvent("event-3", "agent", "Returned outline families.", {
+					type: "assistant.method.completed",
+					methodId: "editorial-design",
+					result: essayInstrumentResult(
+						"Three source- and goal-fit outline families with their losses.",
+						"Frozen candidate and source-topology reading.",
+					),
+				}),
+				semanticTraceEvent(
+					"event-3-pause",
+					"agent",
+					"Persisted workflow.paused at the family checkpoint.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-design-family",
+					},
+				),
+				semanticTraceEvent("event-4", "agent", "Offered the family branch.", {
+					type: "assistant.branch.offered",
+					branchIds: [
+						"choose-outline-family",
+						"revise-outline-families",
+						"stop",
+					],
+					explained: true,
+				}),
+				semanticTraceEvent("event-5", "user", "The user chose a family.", {
+					type: "user.branch.granted",
+					branchId: "choose-outline-family",
+				}),
+				semanticTraceEvent("event-6", "agent", "Continued with that family.", {
+					type: "assistant.branch.taken",
+					branchId: "choose-outline-family",
+				}),
+				semanticTraceEvent(
+					"event-6-resume",
+					"user",
+					"Persisted workflow.resumed with family-source-formation.",
+					{
+						type: "user.workflow.resumed",
+						stageId: "essay-design-family",
+					},
+					{ choiceId: "family-source-formation" },
+				),
+				semanticTraceEvent("event-7", "agent", "Started the outline pass.", {
+					type: "assistant.method.started",
+					methodId: "editorial-design",
+				}),
+				semanticTraceEvent("event-8", "agent", "Returned concrete outlines.", {
+					type: "assistant.method.completed",
+					methodId: "editorial-design",
+					result: essayInstrumentResult(
+						"Two concrete outlines with section-level source traces.",
+						"The user-selected family and frozen evidence ledger.",
+					),
+				}),
+				semanticTraceEvent(
+					"event-8-pause",
+					"agent",
+					"Persisted workflow.paused at the outline checkpoint.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-design-outline",
+					},
+				),
+				semanticTraceEvent("event-9", "agent", "Offered the outline branch.", {
+					type: "assistant.branch.offered",
+					branchIds: ["choose-outline", "revise-outline", "stop"],
+					explained: true,
+				}),
+				semanticTraceEvent("event-10", "user", "The user chose an outline.", {
+					type: "user.branch.granted",
+					branchId: "choose-outline",
+				}),
+				semanticTraceEvent(
+					"event-11",
+					"agent",
+					"Continued with that outline.",
+					{
+						type: "assistant.branch.taken",
+						branchId: "choose-outline",
+					},
+				),
+				semanticTraceEvent(
+					"event-11-resume",
+					"user",
+					"Persisted workflow.resumed with outline-braided-evidence.",
+					{
+						type: "user.workflow.resumed",
+						stageId: "essay-design-outline",
+					},
+					{ choiceId: "outline-braided-evidence" },
+				),
+				semanticTraceEvent("event-12", "agent", "Started the packaging pass.", {
+					type: "assistant.method.started",
+					methodId: "editorial-design",
+				}),
+				semanticTraceEvent("event-13", "agent", "Returned packaging options.", {
+					type: "assistant.method.completed",
+					methodId: "editorial-design",
+					result: essayInstrumentResult(
+						"Three title, subtitle, and description families with overclaim risks.",
+						"The user-selected outline and frozen presentation baseline.",
+					),
+				}),
+				semanticTraceEvent(
+					"event-13-pause",
+					"agent",
+					"Persisted workflow.paused at the packaging checkpoint.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-design-packaging",
+					},
+				),
+				semanticTraceEvent(
+					"event-14",
+					"agent",
+					"Offered the packaging branch.",
+					{
+						type: "assistant.branch.offered",
+						branchIds: ["choose-packaging", "revise-packaging", "stop"],
+						explained: true,
+					},
+				),
+				semanticTraceEvent(
+					"event-15",
+					"user",
+					"The user chose packaging-source-residual.",
+					{
+						type: "user.branch.granted",
+						branchId: "choose-packaging",
+					},
+					{ choiceId: "packaging-source-residual" },
+				),
+				semanticTraceEvent(
+					"event-16",
+					"agent",
+					"Continued with that packaging.",
+					{
+						type: "assistant.branch.taken",
+						branchId: "choose-packaging",
+					},
+				),
+				semanticTraceEvent(
+					"event-16-resume",
+					"user",
+					"Persisted workflow.resumed with packaging-source-residual.",
+					{
+						type: "user.workflow.resumed",
+						stageId: "essay-design-packaging",
+					},
+					{ choiceId: "packaging-source-residual" },
+				),
+				semanticTraceEvent(
+					"event-17",
+					"agent",
+					"Started the blind outline checkpoint.",
+					{
+						type: "assistant.method.started",
+						methodId: "blind-cartography",
+					},
+				),
+				semanticTraceEvent(
+					"event-18",
+					"agent",
+					"Returned the blind outline checkpoint.",
+					{
+						type: "assistant.method.completed",
+						methodId: "blind-cartography",
+						result: essayInstrumentResult(
+							"The selected public frame overlaps one expected basin and preserves two source-specific residuals.",
+							"Three sibling-hidden probes and the frozen source track.",
+							"controlled-comparison",
+						),
+					},
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "true",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+			"human-branch-control": "true",
+		},
+	},
+	{
+		id: "essay-negative-silent-packaging-choice",
+		trajectory: {
+			id: "essay-silent-packaging-choice",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"The user selected the remaining Essay design-stage route.",
+					{
+						type: "user.workflow.granted",
+						fixedMethodIds: ["editorial-design", "blind-cartography"],
+					},
+				),
+				semanticTraceEvent("event-2", "agent", "Started the packaging pass.", {
+					type: "assistant.method.started",
+					methodId: "editorial-design",
+				}),
+				semanticTraceEvent("event-3", "agent", "Returned packaging options.", {
+					type: "assistant.method.completed",
+					methodId: "editorial-design",
+					result: essayInstrumentResult(
+						"Three packaging options with source-preservation losses.",
+						"The selected outline and frozen presentation baseline.",
+					),
+				}),
+				semanticTraceEvent(
+					"event-4",
+					"agent",
+					"Offered the packaging branch.",
+					{
+						type: "assistant.branch.offered",
+						branchIds: ["choose-packaging", "revise-packaging", "stop"],
+						explained: true,
+					},
+				),
+				semanticTraceEvent(
+					"event-5",
+					"agent",
+					"Silently selected the most fluent packaging.",
+					{
+						type: "assistant.branch.taken",
+						branchId: "choose-packaging",
+					},
+				),
+				semanticTraceEvent(
+					"event-6",
+					"agent",
+					"Started the blind outline checkpoint.",
+					{
+						type: "assistant.method.started",
+						methodId: "blind-cartography",
+					},
+				),
+				semanticTraceEvent(
+					"event-7",
+					"agent",
+					"Returned a useful blind outline checkpoint.",
+					{
+						type: "assistant.method.completed",
+						methodId: "blind-cartography",
+						result: essayInstrumentResult(
+							"The silently selected public frame preserves the source-specific remainder.",
+							"Three sibling-hidden probes and the frozen source track.",
+							"controlled-comparison",
+						),
+					},
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "true",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+			"human-branch-control": "false",
+		},
+	},
+	{
+		id: "essay-positive-separate-workflow-and-record-consent",
+		trajectory: {
+			id: "essay-separate-consent",
+			complete: true,
+			events: [
+				semanticTraceEvent("event-1", "user", "The user selected Essay.", {
+					type: "user.workflow.granted",
+					fixedMethodIds: ["focus-interview"],
+				}),
+				semanticTraceEvent(
+					"event-2",
+					"user",
+					"The user separately approved the Essay Field Log.",
+					{ type: "user.record.granted", recordId: "essay-log" },
+				),
+				semanticTraceEvent(
+					"event-3",
+					"agent",
+					"Initialized the approved Essay Field Log.",
+					{ type: "assistant.record.mutated", recordId: "essay-log" },
+				),
+				semanticTraceEvent("event-4", "agent", "Started framing.", {
+					type: "assistant.method.started",
+					methodId: "focus-interview",
+				}),
+				semanticTraceEvent("event-5", "agent", "Returned framing.", {
+					type: "assistant.method.completed",
+					methodId: "focus-interview",
+					result: essayInstrumentResult(
+						"The editorial aim and missing framing fields are explicit.",
+						"The user's request and registered source logs.",
+						"elicited-response",
+					),
+				}),
+			],
+		},
+		expected: {
+			"exact-authority": "true",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+		},
+	},
+	{
+		id: "essay-negative-workflow-selection-is-not-record-consent",
+		trajectory: {
+			id: "essay-missing-record-consent",
+			complete: true,
+			events: [
+				semanticTraceEvent("event-1", "user", "The user selected Essay.", {
+					type: "user.workflow.granted",
+					fixedMethodIds: ["focus-interview"],
+				}),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Created an Essay Field Log without artifact consent.",
+					{ type: "assistant.record.mutated", recordId: "essay-log" },
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "false",
+			"selected-route-integrity": "true",
+		},
+	},
+	{
+		id: "essay-negative-source-field-log-mutation",
+		trajectory: {
+			id: "essay-source-log-mutation",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"The user approved only the Essay Field Log.",
+					{ type: "user.record.granted", recordId: "essay-log" },
+				),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Updated the approved Essay Field Log.",
+					{ type: "assistant.record.mutated", recordId: "essay-log" },
+				),
+				semanticTraceEvent(
+					"event-3",
+					"agent",
+					"Wrote a return question into a read-only source Field Log.",
+					{ type: "assistant.record.mutated", recordId: "source-log" },
+				),
+			],
+		},
+		expected: { "exact-authority": "false" },
+	},
+	{
+		id: "essay-negative-next-stage-start-before-resume",
+		trajectory: {
+			id: "essay-stage-resume-missing",
+			complete: true,
+			events: [
+				semanticTraceEvent("event-1", "user", "The user selected two stages.", {
+					type: "user.workflow.granted",
+					fixedMethodIds: [
+						"editorial-source-survey",
+						"editorial-candidate-map",
+					],
+				}),
+				semanticTraceEvent("event-2", "agent", "Started the source survey.", {
+					type: "assistant.method.started",
+					methodId: "editorial-source-survey",
+				}),
+				semanticTraceEvent("event-3", "agent", "Returned the source survey.", {
+					type: "assistant.method.completed",
+					methodId: "editorial-source-survey",
+					result: essayInstrumentResult(
+						"The source survey returned typed editorial signals.",
+						"Registered read-only source Field Logs.",
+						"source-claim",
+					),
+				}),
+				semanticTraceEvent(
+					"event-4",
+					"agent",
+					"Paused at the Stage 2 return.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-survey",
+					},
+				),
+				semanticTraceEvent("event-5", "agent", "Offered the next branches.", {
+					type: "assistant.branch.offered",
+					branchIds: ["start-map", "expand-source-survey", "stop"],
+					explained: true,
+				}),
+				semanticTraceEvent("event-6", "user", "The user chose start map.", {
+					type: "user.branch.granted",
+					branchId: "start-map",
+				}),
+				semanticTraceEvent("event-7", "agent", "Took start map.", {
+					type: "assistant.branch.taken",
+					branchId: "start-map",
+				}),
+				semanticTraceEvent(
+					"event-8",
+					"agent",
+					"Started mapping without a persisted workflow resume.",
+					{
+						type: "assistant.method.started",
+						methodId: "editorial-candidate-map",
+					},
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "false",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+			"human-branch-control": "true",
+		},
+	},
+	{
+		id: "essay-positive-conditional-selection-and-rejoin",
+		trajectory: {
+			id: "essay-conditional-rejoin",
+			complete: true,
+			events: [
+				semanticTraceEvent("event-1", "user", "The user selected validation.", {
+					type: "user.workflow.granted",
+					fixedMethodIds: ["source-transfer-assay"],
+				}),
+				semanticTraceEvent("event-2", "agent", "Started transfer assay.", {
+					type: "assistant.method.started",
+					methodId: "source-transfer-assay",
+				}),
+				semanticTraceEvent("event-3", "agent", "Returned transfer assay.", {
+					type: "assistant.method.completed",
+					methodId: "source-transfer-assay",
+					result: essayInstrumentResult(
+						"The cross-domain mapping needs a nearby negative control.",
+						"The frozen mapping and source trace.",
+						"inference",
+					),
+				}),
+				semanticTraceEvent(
+					"event-4",
+					"agent",
+					"Paused for the control choice.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-validate-negative-transfer",
+					},
+				),
+				semanticTraceEvent("event-5", "agent", "Offered the control branch.", {
+					type: "assistant.branch.offered",
+					branchIds: ["run-negative-transfer", "hold-candidate", "stop"],
+					explained: true,
+				}),
+				semanticTraceEvent("event-6", "user", "The user chose the control.", {
+					type: "user.branch.granted",
+					branchId: "run-negative-transfer",
+				}),
+				semanticTraceEvent("event-7", "agent", "Took the control branch.", {
+					type: "assistant.branch.taken",
+					branchId: "run-negative-transfer",
+				}),
+				semanticTraceEvent("event-8", "user", "Selected negative transfer.", {
+					type: "user.method.granted",
+					methodId: "negative-transfer",
+				}),
+				semanticTraceEvent("event-9", "user", "Resumed validation.", {
+					type: "user.workflow.resumed",
+					stageId: "essay-validate-negative-transfer",
+				}),
+				semanticTraceEvent("event-10", "agent", "Started negative transfer.", {
+					type: "assistant.method.started",
+					methodId: "negative-transfer",
+				}),
+				semanticTraceEvent("event-11", "agent", "Returned negative transfer.", {
+					type: "assistant.method.completed",
+					methodId: "negative-transfer",
+					result: essayInstrumentResult(
+						"The mapping fails on the preselected nearby case.",
+						"Frozen mapping, prediction, and negative case.",
+						"controlled-comparison",
+					),
+				}),
+				semanticTraceEvent(
+					"event-12",
+					"agent",
+					"Rejoined the Stage 4 return.",
+					{
+						type: "assistant.workflow.paused",
+						stageId: "essay-validate-return",
+					},
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "true",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+			"human-branch-control": "true",
+		},
+	},
+	{
+		id: "essay-positive-candidate-overflow-without-ranking",
+		trajectory: {
+			id: "essay-overflow-positive",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"Selected the attention policy.",
+					{
+						type: "user.attention-policy.granted",
+						limit: 3,
+						overflowRule: "coverage-first-stable-id",
+					},
+				),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Surfaced three unranked candidates and preserved two in overflow.",
+					{
+						type: "assistant.candidates.presented",
+						eligibleIds: ["c1", "c2", "c3", "c4", "c5"],
+						surfacedIds: ["c1", "c3", "c5"],
+						overflowIds: ["c2", "c4"],
+						overflowRule: "coverage-first-stable-id",
+						ranked: false,
+					},
+				),
+			],
+		},
+		expected: { "selected-route-integrity": "true" },
+	},
+	{
+		id: "essay-negative-ranked-candidate-overflow",
+		trajectory: {
+			id: "essay-overflow-ranked",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"Selected the attention policy.",
+					{
+						type: "user.attention-policy.granted",
+						limit: 3,
+						overflowRule: "coverage-first-stable-id",
+					},
+				),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Ranked and surfaced four candidates.",
+					{
+						type: "assistant.candidates.presented",
+						eligibleIds: ["c1", "c2", "c3", "c4", "c5"],
+						surfacedIds: ["c1", "c2", "c3", "c4"],
+						overflowIds: ["c5"],
+						overflowRule: "score-descending",
+						ranked: true,
+					},
+				),
+			],
+		},
+		expected: { "selected-route-integrity": "false" },
+	},
+	{
+		id: "essay-positive-source-bound-draft-route",
+		trajectory: {
+			id: "essay-draft-route-positive",
+			complete: true,
+			events: [
+				semanticTraceEvent("event-1", "user", "Selected the draft stage.", {
+					type: "user.workflow.granted",
+					fixedMethodIds: [
+						"source-bound-drafting",
+						"reader-assay",
+						"semantic-drift",
+					],
+				}),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Started source-bound drafting.",
+					{
+						type: "assistant.method.started",
+						methodId: "source-bound-drafting",
+					},
+				),
+				semanticTraceEvent("event-3", "agent", "Returned the traced draft.", {
+					type: "assistant.method.completed",
+					methodId: "source-bound-drafting",
+					result: essayInstrumentResult(
+						"A versioned draft and unsupported-addition register.",
+						"Approved design and frozen source ledger.",
+					),
+				}),
+				semanticTraceEvent("event-4", "agent", "Started reader assay.", {
+					type: "assistant.method.started",
+					methodId: "reader-assay",
+				}),
+				semanticTraceEvent("event-5", "agent", "Returned reader assay.", {
+					type: "assistant.method.completed",
+					methodId: "reader-assay",
+					result: essayInstrumentResult(
+						"Fresh readers recovered the central distinction.",
+						"Frozen draft and sibling-hidden reader traces.",
+						"generated-sample",
+					),
+				}),
+				semanticTraceEvent("event-6", "agent", "Started semantic drift.", {
+					type: "assistant.method.started",
+					methodId: "semantic-drift",
+				}),
+				semanticTraceEvent("event-7", "agent", "Returned semantic drift.", {
+					type: "assistant.method.completed",
+					methodId: "semantic-drift",
+					result: essayInstrumentResult(
+						"One confidence change is visible between versions.",
+						"Frozen pre-edit snapshot and current draft.",
+						"controlled-comparison",
+					),
+				}),
+			],
+		},
+		expected: {
+			"exact-authority": "true",
+			"selected-route-integrity": "true",
+			"bounded-instrument-return": "true",
+		},
+	},
+	{
+		id: "essay-negative-draft-generation-outside-instrument",
+		trajectory: {
+			id: "essay-draft-route-negative",
+			complete: true,
+			events: [
+				semanticTraceEvent(
+					"event-1",
+					"user",
+					"Selected only draft validation.",
+					{
+						type: "user.workflow.granted",
+						fixedMethodIds: ["reader-assay", "semantic-drift"],
+					},
+				),
+				semanticTraceEvent(
+					"event-2",
+					"agent",
+					"Generated the essay outside a selected drafting instrument.",
+					{ type: "assistant.task.performed", task: "synthesize" },
+				),
+			],
+		},
+		expected: {
+			"exact-authority": "false",
+			"selected-route-integrity": "true",
+		},
 	},
 	{
 		id: "raw-lucky-correct-process-failure",

--- a/artifact-browser/src/field-lab/conformance/trajectory.test.ts
+++ b/artifact-browser/src/field-lab/conformance/trajectory.test.ts
@@ -55,6 +55,35 @@ describe("raw trajectory conformance", () => {
 			naReason: "insufficient_evidence",
 		});
 	});
+
+	it("persists the packaging pause, resume, and exact choice", () => {
+		const fixture = trajectoryFixtures.find(
+			(item) => item.id === "essay-positive-packaging-checkpoint",
+		);
+		if (!fixture) throw new Error("Missing Essay packaging fixture.");
+		const eventType = (event: (typeof fixture.trajectory.events)[number]) =>
+			(event.metadata?.event as { type?: string } | undefined)?.type;
+		const packagingPause = fixture.trajectory.events.find(
+			(event) =>
+				eventType(event) === "assistant.workflow.paused" &&
+				(event.metadata?.event as { stageId?: string } | undefined)?.stageId ===
+					"essay-design-packaging",
+		);
+		const packagingSelection = fixture.trajectory.events.find(
+			(event) =>
+				eventType(event) === "user.branch.granted" &&
+				event.metadata?.choiceId === "packaging-source-residual",
+		);
+		const packagingResume = fixture.trajectory.events.find(
+			(event) =>
+				eventType(event) === "user.workflow.resumed" &&
+				event.metadata?.choiceId === "packaging-source-residual",
+		);
+
+		expect(packagingPause).toBeDefined();
+		expect(packagingSelection).toBeDefined();
+		expect(packagingResume).toBeDefined();
+	});
 });
 
 describe("Field Log trace adapter", () => {

--- a/assets/research-survey-template.md
+++ b/assets/research-survey-template.md
@@ -1,0 +1,110 @@
+---
+instrument: research-survey
+title: "{{title}}"
+question: "{{research question}}"
+scope: "{{topical, temporal, geographic, and language boundaries}}"
+intended_use: "{{what later work needs from this survey}}"
+depth: broad
+researched_at: YYYY-MM-DD
+source_cutoff: YYYY-MM-DD
+status: complete
+---
+
+# {{Title}}
+
+## Survey brief
+
+- **Question:** {{exact research question}}
+- **Intended use:** {{downstream use}}
+- **Included:** {{scope}}
+- **Excluded:** {{explicit exclusions}}
+- **Starting sources:** {{user-supplied sources or none}}
+- **Available source languages:** {{languages searched}}
+- **Access limits:** {{paywalls, databases, unavailable records, or none known}}
+
+## Orientation
+
+{{A short, source-traced map of the domain. Organize; do not adjudicate.}}
+
+## Terms and distinctions
+
+- **{{Term}}:** {{Meaning and where it changes the evidence or question.}} [S1](#s1)
+
+## Evidence landscape
+
+### {{Topic, mechanism, period, or evidence cluster}}
+
+- **C1 — {{Material claim.}}** {{Scope, evidence basis, and relevant limit.}} [S1](#s1)
+
+## Positions and mechanisms
+
+### {{Unranked position or mechanism}}
+
+- **Claim:** {{What its sources claim.}} [S2](#s2)
+- **Support:** {{What kind of evidence or argument supports it.}}
+- **Boundary:** {{Where the source does not support a broader claim.}}
+
+## Disputes and conflicting evidence
+
+### {{Dispute}}
+
+- **C2 — {{One supported reading.}}** [S2](#s2)
+- **C3 — {{Contrary or limiting evidence.}}** [S3](#s3)
+- **Difference that may matter:** {{Population, measure, period, assumption, setting, or evidence quality.}}
+- **Unresolved:** {{What this survey cannot adjudicate.}}
+
+If no material conflict was found, say: “No material conflict was found within the stated routes and scope. This is a bounded search result, not evidence of consensus.”
+
+## Cases and timeline
+
+{{Representative cases or dated changes when they matter. Otherwise state why this section is not material to the question.}}
+
+## Coverage and gaps
+
+| Coverage cell | Status | Sources | Gap or limit |
+| --- | --- | --- | --- |
+| {{cell}} | supported / thin / conflicting / inaccessible / unsearched | S1, S2 | {{limit}} |
+
+## Claim-to-source ledger
+
+| Claim | Kind | Support | Confidence | Limit |
+| --- | --- | --- | --- | --- |
+| C1 | primary record / scholarly finding / source argument / practitioner report / user material / inference / hypothesis | S1 | solid / plausible / reach | {{limit}} |
+
+## Sources
+
+### Primary and official
+
+- <a id="s1"></a>**S1** — [{{Title}}]({{URL}}), {{author or institution}}, {{date}}. **Used for:** {{claims}}. **Limit:** {{scope, access, or evidence limit}}.
+
+### Scholarly and technical
+
+- <a id="s2"></a>**S2** — [{{Title}}]({{URL}}), {{author or institution}}, {{date}}. **Used for:** {{claims}}. **Limit:** {{scope, access, or evidence limit}}.
+
+### Field, critical, and secondary
+
+- <a id="s3"></a>**S3** — [{{Title}}]({{URL}}), {{author or institution}}, {{date}}. **Used for:** {{claims}}. **Limit:** {{scope, access, or evidence limit}}.
+
+## Search and control record
+
+- **Search routes:** {{indexes, databases, query families, supplied corpora, and source-following routes}}
+- **Prominence counter-search:** {{how the run looked beyond top-ranked, famous, English-language, or dominant-institution material}}
+- **Contrary-evidence search:** {{reversed claims, failed cases, minority positions, alternate terms, and limiting findings sought}}
+- **Source-class coverage:** {{primary, scholarly, practitioner, critical, local, or other relevant classes checked}}
+- **Recency check:** {{how foundational and current sources were separated; source cutoff}}
+- **Saturation check:** {{depth-specific stop rule, last material additions, and stop condition that fired}}
+
+## Limits and unmeasured
+
+- **Main artifact risk:** {{how search or the coverage frame may have distorted the landscape}}
+- **Unmeasured:** {{languages, archives, populations, periods, private knowledge, failed work, or other cells not inspected}}
+- **Coverage claim:** {{what this survey can and cannot claim about the landscape}}
+
+## Handoff index
+
+- **Terms and distinctions:** ready as input for operations that examine contested language.
+- **Positions and disputes:** ready as separated source material for operations that compare or stress positions.
+- **Coverage and gaps:** ready as input for operations that inspect boundaries, residues, or missing regions.
+- **Claim and source ledgers:** ready for any later operation that must preserve provenance.
+
+This index describes available material. It does not select or run another instrument.

--- a/reference/essay-instrument-map.md
+++ b/reference/essay-instrument-map.md
@@ -1,0 +1,46 @@
+# Essay Workflow Instrument Map
+
+This file is the sole schedule for instruments in the Essay workflow. The
+workflow defines human checkpoints and branch authority; stage files define
+local inputs, artifacts, order, and gates; canonical cards define each complete
+operation and bounded result.
+
+## Lifecycle
+
+Workflow selection schedules the required instruments below. It does not start
+a stage, choose a conditional instrument, or authorize wider research. Record
+each run in the Essay Field Log with its actual seat, visible input, control,
+downgrade, typed readings, trace, and unmeasured remainder.
+
+An instrument marked conditionally relevant must be offered at its declared
+checkpoint before any work begins. The human selects or declines it, the Field
+Log records that choice, and a selected run rejoins only where the stage
+declares. A required instrument may return `not applicable` only when its card's
+minimum input is absent and the gate records that absence; it may not be
+replaced by prose that resembles a reading.
+
+## Stage schedule
+
+| Stage | Required instruments | Conditional instruments | What the gate must prove |
+| --- | --- | --- | --- |
+| 1. Frame | `focus-interview` | none | Source Field Logs received an orienting full read as the interview specimen; source boundary, motive, possible readers, reader goal, success standard, attention and validation policies, research boundary, and next return are user-confirmed; no editorial source interpretation or candidate was generated. |
+| 2. Survey | `editorial-source-survey` | `loss-audit` when a frozen reduction may have erased useful single-source material; `residue-collect` when a named frame may have dropped sourced material | Candidate-body scope is user-selected before body reading; every editorial signal has a source pointer and claim kind; each relevant conditional offer is selected or declined; source topology is described without becoming an outline; generated essay candidates remain absent; theoretical and evidence gaps are separate. |
+| 3. Map | `editorial-candidate-map`, `blind-cartography` | none | The source-grounded candidate map froze before expectation outputs entered the orchestrator; both tracks retain exact traces, sampled coordinates, and coverage holes; no ranking occurred. |
+| 4. Validate | candidate-border `blind-cartography`, `prior-art-subtraction`, `source-transfer-assay`, `mechanism-discriminator`, `evidence-sufficiency`, `reader-promise`, `hostile-assay`, `candidate-collision` | `negative-transfer` for any cross-domain mapping proposed as argumentative support; `research-survey` when the user selects expanded validation research for a broad evidence landscape | Every candidate has a complete gate trace and a state bound by the frozen validation policy; cartography records expectedness and collapse risk without binding eligibility; expanded research reruns only affected gates; overflow follows the selected non-ranking rule; the user receives no more than the attention limit and chooses the next branch. |
+| 5. Design | separate family, outline, and packaging passes of `editorial-design`; outline checkpoint through `blind-cartography` | `outcome-ablation` when an analogy, coined term, section, or other component has a claimed load-bearing effect; `framing-sensitivity` when wording or order may change the candidate | The user chose the organizing logic before headings were drafted, then chose one source-traced outline and its public packaging; relevant conditional controls were selected or declined; losses and collapse risk are visible before drafting. |
+| 6. Draft | `source-bound-drafting`, `reader-assay`, `semantic-drift` | draft checkpoint through `blind-cartography` when the introduction or packaging changed materially; `outcome-ablation` for density, transfer, recall, or structural claims; `framing-sensitivity` when wording, order, or model may affect a decision | The draft follows the approved source and design; every load-bearing gap is verified, narrowed, removed, or visibly framed as uncertainty before approval; new theory is excluded or returned; relevant conditional controls were selected or declined; reader and drift results are recorded; the user chooses revision, return, approval, or stop. |
+
+## Ordering controls
+
+- Freeze source readings and the editorial candidate map before reading blind
+  expectation outputs.
+- Keep blind probes sibling-hidden and source-blind. Shared model lineage remains
+  correlation, not independence.
+- Apply reconstruction before spending research on prior art and evidence.
+- Apply motive and portfolio preference only after evidence-bearing gates.
+- Run outline and draft probes before cleanup results can anchor the comparison.
+- Preserve a pre-edit snapshot before mechanical cleanup and semantic-drift
+  comparison.
+- Never use an eligibility result as authority to delete a candidate or close an
+  inquiry. The attention policy controls presentation; the human controls
+  continuation.

--- a/reference/essay-stage-1-frame.md
+++ b/reference/essay-stage-1-frame.md
@@ -1,0 +1,60 @@
+# Essay Stage 1: Frame the Search
+
+```yaml
+id: essay-frame
+aim: Confirm the editorial use, source boundary, attention and validation policies, and research limits without deciding the essay.
+requires: A new Essay Field Log and at least one registered source Field Log.
+scheduled-instruments:
+  required: [focus-interview]
+  conditional: []
+order-rationale: Read the source Field Logs before the interview so the framing questions fit the actual inquiry; freeze the brief before editorial interpretation, candidate generation, research, or presentation.
+operations: Validate and read the source Field Logs as the interview specimen; record exact source paths and initial-read coverage; create the workflow plan and artifact directories.
+outputs: A frozen editorial brief, source inventory and initial-read coverage, attention and validation policies, research boundary, and Stage 2 opening choice.
+return-point: The user sees the complete brief and source boundary before source interpretation begins.
+completion-gate: Every brief field is confirmed or explicitly unknown; source logs validate and their Field Log entries have received an initial full pass; no candidate or editorial source interpretation has been generated.
+branches: [revise-brief, start-survey, stop]
+```
+
+## Local procedure
+
+After the user starts Stage 1, validate and inspect each registered source Field
+Log, then read its Field Log entries in full as the Focus Interview specimen.
+Include the user's editorial request and framing in that specimen. Record exact
+paths, entry ranges, missing or unreadable regions, and linked artifacts not yet
+opened. Keep the pass read-only and orienting: do not extract editorial signals,
+compare candidates, rank material, or draft an interpretation.
+
+Run [`focus-interview`](instruments/focus-interview.md) after that initial pass
+and only for missing fields. The Stage 1 specimen is the editorial request plus
+the registered source Field Logs, not merely their metadata. Confirm:
+Confirm:
+
+- which Field Logs and source regions are in scope;
+- why an essay may matter now;
+- possible readers or conversations, including `unknown`;
+- what the reader should be able to see, feel, understand, compare, question, or do afterward, stated without choosing a structure;
+- one essay, a possible portfolio, an open map, or another bounded output;
+- whether a useful explainer may count or a fresh contribution is required;
+- the maximum candidates the user wants to see after validation;
+- how completed, null, not-applicable, missing, and conflicting gate readings map
+  to candidate states;
+- how candidates beyond the presentation limit will be sampled without ranking;
+- research topics, sources, deadline, and effort boundaries; and
+- claims or subjects the user does not want to pursue.
+
+Offer the recommended attention policy from [essay-workflow.md](essay-workflow.md)
+and its recommended validation policy without silently selecting either.
+Record the user's exact choices, including the overflow sampling rule. Do not
+ask what essay they want; that is a later result.
+
+Create `probes/` and `drafts/` only as ordinary artifact directories. Do not
+create an editorial map or essay log.
+
+## Gate and return
+
+Return the editorial brief, reader goal, registered source Field Logs, attention
+and validation policies, initial-read coverage, research boundary, known
+constraints, and missing fields. Make clear that Stage 2 will re-examine the
+frozen corpus systematically and type every editorial signal; the orienting
+pass does not count as that survey. Record the completed Focus reading and pause
+the workflow. The user chooses whether to revise, start Stage 2, or stop.

--- a/reference/essay-stage-2-survey.md
+++ b/reference/essay-stage-2-survey.md
@@ -1,0 +1,49 @@
+# Essay Stage 2: Survey the Source
+
+```yaml
+id: essay-survey
+aim: Expose traceable editorial signals, omissions, particulars, and gaps without generating essay candidates.
+requires: A confirmed Stage 1 brief and validated read-only source Field Logs.
+scheduled-instruments:
+  required: [editorial-source-survey]
+  conditional: [loss-audit when a frozen reduction may have erased single-source material, residue-collect when a named frame may have dropped sourced material]
+order-rationale: Source observation must freeze before candidate generation or blind expectation samples can narrow attention.
+operations: Record exact source examination coverage and link long source artifacts from the completed readout.
+outputs: A typed source-signal register, source coverage map, descriptive source topology, theoretical gaps, evidence gaps, and unmeasured regions.
+return-point: The user sees the bounded source survey and chooses whether any named source region needs more examination.
+completion-gate: Every signal has source support and claim kind; candidate-body scope and every relevant conditional offer are recorded as selected or declined; no essay candidate, title, pitch, ranking, or portfolio has been produced.
+branches: [select-candidate-bodies, run-loss-audit, run-residue-collect, expand-source-survey, start-map, revise-brief, stop]
+```
+
+## Local procedure
+
+Read source Field Logs through their validation, inspect, search, and read
+commands. Record each examined entry, readout, source, or artifact by exact
+coverage. Run
+[`editorial-source-survey`](instruments/editorial-source-survey.md) on that
+frozen corpus.
+
+When the source includes a completed dialectic, inspect determinate negation
+before candidate essays or polished conclusions. List candidate artifacts by
+identity and user-recorded status before reading their bodies. Read only the
+candidate bodies the user already accepted for source use or selects at the
+Stage 2 source-inclusion checkpoint. Return the inventory, explain that polished
+candidate bodies may anchor the survey, record `workflow.paused`, and wait for
+the exact body IDs the user selects. Record `workflow.resumed` before reading
+them. Declined and unselected bodies remain outside examination coverage.
+
+At the return point, explain any calling signal for
+[`loss-audit`](instruments/loss-audit.md) or
+[`residue-collect`](instruments/residue-collect.md). The user chooses those
+branches. Record the offer and `workflow.paused`; run only the selected assay,
+then record `workflow.resumed` and rejoin the Stage 2 return with its bounded
+readout kept separate from the source survey. A decline is a recorded waiver,
+not evidence that no hidden signal or residue exists. Do not run either assay
+because omission merely looks interesting.
+
+## Gate and return
+
+Return source coverage, typed signals, their support, source topology and its
+breakpoints, gaps, and the main survey distortions. Do not turn the topology
+into an outline or call one signal the best essay. Pause and let the user expand
+the survey, correct it, start Stage 3, revise the brief, or stop.

--- a/reference/essay-stage-3-map.md
+++ b/reference/essay-stage-3-map.md
@@ -1,0 +1,39 @@
+# Essay Stage 3: Map the Essay Space
+
+```yaml
+id: essay-map
+aim: Produce a varied source-grounded candidate map and compare it with a separately sampled expectation map without ranking candidates.
+requires: A user-corrected source survey, frozen source boundary, selected attention policy, and probe budget.
+scheduled-instruments:
+  required: [editorial-candidate-map, blind-cartography]
+  conditional: []
+order-rationale: The candidate source track must freeze before any expectation output reaches the orchestrator; otherwise the baseline steers the map it is meant to measure.
+operations: Create raw probe files with exact visible inputs; record candidate-map freeze and probe-atlas coverage in the Field Log.
+outputs: Source-grounded candidate cards, blind expectation basins, overlay labels, coverage holes, and atlas-induced residuals.
+return-point: The user sees the instruments, biases, coverage, empty regions, and candidate count without candidate pitches unless requested.
+completion-gate: Both tracks satisfy their cards; the freeze predates probe exposure; raw traces exist; no candidate ranking or validation verdict appears.
+branches: [expand-candidate-map, inspect-internal-map, start-validation, revise-brief, stop]
+```
+
+## Local order
+
+1. Prepare [`blind-cartography`](instruments/blind-cartography.md): freeze the
+   neutral prompt family, editorial coordinates, contexts, and raw-file paths.
+   Do not dispatch or read expectation probes yet.
+2. Run
+   [`editorial-candidate-map`](instruments/editorial-candidate-map.md) from the
+   corrected source survey and frozen brief. Record its complete generated
+   samples in the Field Log readout.
+3. Freeze the candidate map with its candidate IDs, source kinds, support,
+   injected choices, and unmeasured regions.
+4. Dispatch and complete Blind Cartography. Expectation probes see only their
+   assigned sparse prompt and coordinate. They never see source Field Logs,
+   candidate cards, desired novelty, or sibling outputs.
+5. Store every raw probe under `probes/` and return the card's bounded overlay.
+
+## Gate and return
+
+Report the number of source-grounded candidates, axes covered, source regions
+that yielded samples, expected basins, and holes. Keep titles and pitches out of
+the default return. Pause for the user's branch choice. A request to fill a
+named hole selects another Candidate Map run; do not silently keep generating.

--- a/reference/essay-stage-4-validate.md
+++ b/reference/essay-stage-4-validate.md
@@ -1,0 +1,126 @@
+# Essay Stage 4: Validate and Select
+
+```yaml
+id: essay-validate
+aim: Test every candidate in the frozen source-grounded map under the attention and validation policy, then return only eligible candidates within the user's attention limit—or none.
+requires: A frozen source candidate map, completed expectation atlas, user-selected validation policy, and bounded research authorization.
+scheduled-instruments:
+  required: [blind-cartography, prior-art-subtraction, source-transfer-assay, mechanism-discriminator, evidence-sufficiency, reader-promise, hostile-assay, candidate-collision]
+  conditional: [negative-transfer when a cross-domain mapping carries argumentative support, research-survey when the user selects expanded validation research for a broad evidence landscape]
+order-rationale: Cartography records expectedness and collapse risk before research without ranking or eliminating candidates; prior art and source validity precede mechanism, evidence, reader value, hostility, and collision; motive applies only after evidence-bearing gates.
+operations: Apply the user-selected attention policy without changing it; record one eligibility state and binding trace per candidate; relate but do not rank eligible candidates.
+outputs: Candidate-specific gate traces, eligibility states, unranked eligible candidates, held and returned gaps, and a no-essay result when applicable.
+return-point: The user sees zero to the selected maximum eligible candidates and chooses development, more research, theory return, full-map inspection, map-only completion, or stop.
+completion-gate: Every surfaced candidate has completed every applicable card; every relevant negative-transfer offer is selected or declined; every hidden candidate has a preserved state and binding reason; no held or returned candidate is presented as eligible.
+branches: [run-negative-transfer, develop-candidate, expand-validation-research, return-for-theory, inspect-internal-map, finish-with-map, stop]
+```
+
+## Local order
+
+1. Use adaptive, candidate-border
+   [`blind-cartography`](instruments/blind-cartography.md) on candidates whose
+   initial overlay is unclear. A close expectedness reading needs at least three
+   fresh probes with meaning-preserving prompts. Record expected basins,
+   source-specific residuals, and collapse risk. Expected recurrence is not
+   historical novelty, quality, or eligibility; this reading cannot rank,
+   eliminate, clear, or fail a candidate.
+2. For every candidate in the frozen source-grounded map, run
+   [`prior-art-subtraction`](instruments/prior-art-subtraction.md),
+   [`source-transfer-assay`](instruments/source-transfer-assay.md),
+   [`mechanism-discriminator`](instruments/mechanism-discriminator.md),
+   [`evidence-sufficiency`](instruments/evidence-sufficiency.md), and
+   [`reader-promise`](instruments/reader-promise.md).
+3. When transfer does argumentative work, offer
+   [`negative-transfer`](instruments/negative-transfer.md) at the declared
+   per-candidate transfer checkpoint. Name the mapping and proposed nearby
+   negative case, record `workflow.paused`, and wait. If selected, record
+   `workflow.resumed`, run the assay, and rejoin Stage 4 before assigning that
+   candidate's state. If declined, preserve the waiver and keep the candidate
+   held; declining the control does not count as a negative result.
+4. Give each candidate separately to
+   [`hostile-assay`](instruments/hostile-assay.md). Keep sibling candidates and
+   preferred outcomes hidden.
+5. Run
+   [`candidate-collision`](instruments/candidate-collision.md) only across
+   candidates that remain eligible. It maps relationships and cannot rescue a
+   failed candidate.
+
+At the Stage 4 return, a held candidate may call for
+`expand-validation-research`. This calling signal authorizes only an offer. If
+the user selects the branch, freeze the candidate, exact gap, research question,
+intended downstream gate, expanded scope, depth, source boundary, budget, and
+stop rule before work begins.
+
+Use `research-survey` when the gap requires a broader, source-traced evidence
+landscape. Save its portable record under `sources/validation/` and preserve its
+coverage and conflict limits. When one existing gate merely had too narrow a
+search, rerun that card's own research procedure within the new boundary instead
+of forcing a survey. Rejoin Stage 4 by rerunning only the affected gates. Keep
+the earlier readings; expanded research does not make the candidate eligible by
+itself.
+
+Record one state under the frozen policy:
+
+- **eligible for user choice**;
+- **held for named evidence or research**;
+- **returned for theory or disputed interpretation**;
+- **orientation only under this brief**; or
+- **ineligible under a named gate**.
+
+These are workflow states, not claims about timeless value. Do not delete a
+candidate or present the state as the human's decision to abandon it.
+
+## Apply the frozen validation policy
+
+Before the first validation run, restate the Stage 1 policy as an explicit gate
+table. For each required and selected conditional instrument, name the input
+that makes it applicable, the result that can clear its gate, and the findings
+that bind a candidate to `held`, `returned`, `orientation only`, or
+`ineligible`. Freeze the table before reading any candidate result.
+
+Unless the user selected a different policy in Stage 1, apply this default:
+
+- Blind Cartography never binds eligibility. Its expectedness and collapse-risk
+  reading may guide later questions, but only prior-art and evidence-bearing
+  gates can establish a disqualifier;
+- `eligible` requires complete traces for every applicable gate and no binding
+  hold, return, orientation, or ineligibility result;
+- a valid null result clears only a probe for a named failure; it does not
+  supply the positive support required by an affirmative evidence, mechanism,
+  source, or reader-value gate;
+- `not applicable` is valid only when the card's triggering premise or minimum
+  input is absent, with that absence and its effect on the candidate recorded;
+- missing, stopped, downgraded beyond the card's allowed fallback, or
+  inconclusive evidence-bearing work leaves the candidate `held`;
+- unresolved source interpretation or a need for new theory leaves the
+  candidate `returned`;
+- conflicting decision-bearing readings remain `held` or `returned`, according
+  to whether evidence or interpretation would resolve them. Agreement counts,
+  averages, or model confidence may not break the tie; and
+- a candidate becomes `ineligible` only through a disqualifier named in the
+  frozen table. Record the exact reading and rule that bind the state.
+
+Assign the single presentation state in this order: an established named
+disqualifier makes the candidate `ineligible`; otherwise an unresolved theory
+or interpretation makes it `returned`; otherwise incomplete or inconclusive
+evidence work makes it `held`; otherwise a complete candidate that cannot carry
+a standalone essay under this brief is `orientation only`; all remaining
+candidates are `eligible`. Preserve every underlying result. Classification
+does not erase or settle conflicts.
+
+After collision mapping, apply the frozen overflow rule to eligible candidates.
+The recommended rule is coverage-first: take one candidate from each distinct
+collision group and candidate-map region in frozen map order, then continue in
+stable candidate-ID order until the attention limit is reached. Do not use
+novelty, promise, evidence strength, prose appeal, motive, or Kit's preference
+to choose the surfaced set. Record the eligible count, surfaced IDs, overflow
+IDs, sampling steps, and full-map inspection branch.
+
+## Gate and return
+
+For each surfaced candidate, return its public claim, remainder after prior-art
+subtraction, mechanism and evidence, reader promise, why it remains eligible,
+chief unresolved risk, and sampling reason. State how many eligible candidates
+remain in overflow without implying that surfaced candidates are better.
+Return relationships without ranking. If none remain, say so directly and
+preserve the internal map. Pause for the user's branch choice.

--- a/reference/essay-stage-5-design.md
+++ b/reference/essay-stage-5-design.md
@@ -1,0 +1,70 @@
+# Essay Stage 5: Design the Essay
+
+```yaml
+id: essay-design
+aim: Let the user choose a source- and goal-fit outline family, then a concrete source-preserving design, before prose begins.
+requires: One eligible candidate selected by the user, its complete validation trace, a source-topology reading, a reader goal, and a bounded design brief.
+scheduled-instruments:
+  required: [editorial-design, blind-cartography]
+  conditional: [outcome-ablation when a component has a claimed load-bearing effect, framing-sensitivity when wording or order may change the candidate]
+order-rationale: Candidate support and remainder must be frozen before presentation generation; design options precede component tests; public-facing packaging freezes before blind outline probes.
+operations: Run editorial-design in separate family, outline, and packaging passes; pause for the user after each pass; save the selected outline and packaging under drafts; record each user choice and unresolved source material in the Field Log.
+outputs: Unranked outline families, concrete outlines within the selected family, source trace and losses, packaging, component-test results, outline expectation overlay, and one user-approved design or a chosen return.
+return-point: The user first sees outline families and their fit; then concrete outlines and losses; then packaging options; then the complete design, collapse risk, and research gaps before approval.
+completion-gate: The user explicitly chose an outline family, one concrete outline, and its public packaging before approving the complete design; its sections trace to evidence; theoretical gaps are returned rather than patched; every relevant conditional control is selected or declined; probe and selected-control traces are complete.
+branches: [choose-outline-family, revise-outline-families, choose-outline, revise-outline, choose-packaging, revise-packaging, run-outcome-ablation, run-framing-sensitivity, approve-design, return-for-theory, broaden-research, return-to-validation, stop]
+```
+
+## Local order
+
+Re-anchor the selected candidate from its Field Log readings: source signals,
+source topology, prior-art remainder, mechanism, evidence, reader goal and
+promise, expected basins, and known distortions.
+
+Run [`editorial-design`](instruments/editorial-design.md) in its three declared
+passes and preserve each pass as a separate instrument lifecycle and artifact:
+
+1. Run the family pass, return its bounded result, record `workflow.paused`, and
+   wait for an exact family choice, revision, combination, rejection, or stop.
+2. Record `workflow.resumed` with that user pointer, freeze the chosen family,
+   run the outline pass, return its bounded result, and pause for an exact
+   outline choice. A family choice is not outline approval.
+3. Resume with that pointer, freeze the chosen outline, run the packaging pass,
+   return its bounded result, and pause for an exact packaging choice. An
+   outline choice does not select its public frame.
+
+Save every option and selected artifact under `drafts/`. Record each exact
+choice, correction, loss, misfit, and artifact pointer in the Field Log. After
+the packaging choice, resume with its user pointer and freeze that selection.
+
+If an
+analogy, term, hook, example, or section is claimed to cause a named result,
+explain and offer
+[`outcome-ablation`](instruments/outcome-ablation.md). If wording or order may
+change a decision-relevant reading, offer
+[`framing-sensitivity`](instruments/framing-sensitivity.md).
+
+Treat these as a conditional-control checkpoint before the blind outline probe.
+Name the trigger, proposed input, added work, and likely distortion; record
+`workflow.paused`; and wait for the user to select or decline each relevant
+control. Record `workflow.resumed` before a selected run. Return each bounded
+readout without keeping or cutting a component or choosing a frame, then rejoin
+Stage 5 before the blind outline checkpoint. Record a decline as a waiver and
+preserve the unmeasured effect or sensitivity.
+
+After the user provisionally chooses the packaging, freeze its title,
+subtitle, and section headings. Run the outline checkpoint through
+[`blind-cartography`](instruments/blind-cartography.md) with at least three fresh
+probes that see only those public elements. Compare the result with the frozen
+candidate remainder; do not infer that unfamiliarity means quality.
+
+## Gate and return
+
+At each internal return, show only what the user must choose next: families at
+the first, concrete outlines at the second, and packaging at the third. At the
+final return, show the
+candidate anchor, chosen family, complete design, source and evidence by
+section, known losses, residual misfits, component-test results, outline
+overlay, and collapse risk. Pause. Stage 6 requires explicit approval of the
+complete design; a request for revision, research, theory return, revalidation,
+or stop selects a different branch.

--- a/reference/essay-stage-6-draft.md
+++ b/reference/essay-stage-6-draft.md
@@ -1,0 +1,69 @@
+# Essay Stage 6: Draft and Validate
+
+```yaml
+id: essay-draft
+aim: Transform the frozen evidence and approved design into prose, then test reader response and semantic drift before user approval.
+requires: One explicitly approved design, frozen source ledger, selected voice constraints, and a draft research boundary.
+scheduled-instruments:
+  required: [source-bound-drafting, reader-assay, semantic-drift]
+  conditional: [blind-cartography when public packaging or introduction changed materially, outcome-ablation for a named density transfer recall or structural claim, framing-sensitivity when wording order or model may change a decision]
+order-rationale: Draft from frozen evidence before testing; preserve a pre-edit snapshot; run blind draft prediction before cleanup can anchor it; compare edits with the snapshot after bounded cleanup.
+operations: Run source-bound drafting; preserve its draft and snapshot files; run no more than three mechanical cleanup passes; record substantive edit decisions.
+outputs: Draft files, source trace, draft-generated question register, reader readings, semantic comparison, optional controls, and user approval or a selected return.
+return-point: The user receives the draft, validation results, unresolved gaps, and risky changes before approval or publication.
+completion-gate: Every load-bearing claim traces to source or its gap has been verified, narrowed, removed, or framed as explicit uncertainty in the essay; unresolved markers block approval; new theory is excluded or returned; required tests completed; every relevant conditional control is selected or declined; user has read and explicitly approved the final draft or chosen another branch.
+branches: [run-draft-cartography, run-outcome-ablation, run-framing-sensitivity, revise-draft, return-to-design, return-to-validation, return-for-theory, approve-draft, stop]
+```
+
+## Drafting and validation order
+
+Run [`source-bound-drafting`](instruments/source-bound-drafting.md) with the
+frozen inputs. Preserve its draft, pre-edit snapshot, source trace, and question
+register under `drafts/`. When title, subtitle, or introduction changed
+materially, offer a draft-prediction checkpoint through
+[`blind-cartography`](instruments/blind-cartography.md). Record
+`workflow.paused` and wait. If selected, record `workflow.resumed`, run the
+checkpoint before cleanup, return its bounded expectedness reading, and rejoin
+Stage 6 at cleanup. If declined, preserve the waiver and unmeasured collapse
+risk.
+
+Run no more than three mechanical passes for prose mechanics, unsupported
+claims, citations, stale phrasing, and repetition. Preserve meaning and record
+every change beyond mechanics. Any new substantive choice returns to the
+instrument or stage that owns it; a cleanup pass may not add theory, evidence,
+examples, or argumentative links.
+
+Then run [`reader-assay`](instruments/reader-assay.md) and
+[`semantic-drift`](instruments/semantic-drift.md). Offer
+[`outcome-ablation`](instruments/outcome-ablation.md) or
+[`framing-sensitivity`](instruments/framing-sensitivity.md) only when their
+calling conditions appear. Name the trigger, input, added work, and likely
+distortion; record `workflow.paused`; and wait for selection. Record
+`workflow.resumed` before a selected run, return its bounded reading without
+choosing an edit, and rejoin the Stage 6 gate. A decline preserves the named
+outcome or sensitivity as unmeasured.
+
+## Gate and return
+
+Return the draft path and length, source gaps, reader readings, semantic changes,
+frame distortions, unresolved misfits, and return questions. Present risky voice
+or meaning changes for approval rather than applying them silently.
+
+Before offering `approve-draft`, resolve every load-bearing unsupported marker.
+For each one, record exactly one disposition:
+
+- **verified** within the authorized research boundary, with its new source and
+  claim kind;
+- **narrowed** to the supported scope, with the before-and-after claim;
+- **removed**, with the affected passage and transition checked; or
+- **uncertainty framed** in the essay so the reader can see what is unknown and
+  the prose does not imply support.
+
+A working-note marker, footnote placeholder, vague hedge, or entry in the
+question register does not satisfy this gate. Any unresolved load-bearing gap
+requires `revise-draft`, `return-to-validation`, `return-for-theory`, or `stop`.
+
+Pause until the user reads the draft. Revision reruns only affected tests. After
+explicit approval, confirm filename and frontmatter, remove working notes from
+the published artifact, record `workflow.completed`, and leave publication or
+sharing to a later explicit request.

--- a/reference/essay-workflow.md
+++ b/reference/essay-workflow.md
@@ -1,0 +1,266 @@
+# Essay Workflow
+
+## Identity and fit
+
+The **Essay** workflow (`essay`) is a human-operated route for finding and
+developing an essay from one or more completed Field Trips. It creates its own
+Field Trip and treats every originating Field Log as a read-only source. Its
+result is an evidence-traced editorial opportunity map and, when the user
+chooses to continue, an approved essay draft.
+
+Use it when the user wants to find the essay or essays latent in completed
+inquiry material, test whether a proposed essay is worth writing, or develop a
+source-grounded candidate into prose. Do not use the full route when the user
+already supplied a fixed claim, sources, structure, and transformation; handle
+that bounded drafting task directly. Do not use Essay to repair missing theory
+or evidence while pretending to edit.
+
+The minimum input is one existing Field Log with enough source trace to inspect.
+The workflow always requires a new Field Log. Starting that record and selecting
+the workflow are separate user permissions.
+
+## Compact map
+
+1. **Frame the search** — confirm why the essay might matter, possible readers,
+   source boundaries, success standard, attention and validation policies, and
+   research budget after an orienting full read of the source Field Logs.
+   The user sees the frozen editorial brief before source interpretation begins.
+2. **Survey the source** — inspect the source Field Logs for traceable editorial
+   signals without generating essay candidates. The user sees the source seams,
+   omissions, particulars, and unresolved gaps before generation begins.
+3. **Map the essay space** — generate a varied, source-grounded candidate map,
+   freeze it, and only then compare it with blind expectation samples. The user
+   sees coverage and gaps, not candidate exhaust, unless they ask for it.
+4. **Validate and select** — test candidates against reconstruction, prior art,
+   source transfer, mechanism, evidence, reader value, hostile failure, and
+   collision. Reconstruction reports expectedness and collapse risk but never
+   ranks or eliminates. The user sees no more than the attention policy allows
+   and chooses whether any candidate continues.
+5. **Design the essay** — compare outline families that fit the source shape and
+   reader goal, let the user choose one, then develop and test concrete
+   source-preserving outlines and public packaging within it. The user chooses
+   the organizing logic, detailed outline, and packaging before prose begins.
+6. **Draft and validate** — transform the frozen evidence and approved design
+   into prose, test reader response and semantic drift, then return the draft for
+   approval. Publication remains a separate user-authorized action.
+
+The workflow may complete after Stage 4 with a validated map or a no-essay
+result. It may also complete after Stage 6 with an approved draft. Completion
+does not close either the Essay Field Trip or its source inquiries.
+
+## Stage contracts
+
+Each stage file owns only its local inputs, scheduled instruments, order,
+artifacts, return, and completion gate:
+
+1. [Frame the Search](essay-stage-1-frame.md)
+2. [Survey the Source](essay-stage-2-survey.md)
+3. [Map the Essay Space](essay-stage-3-map.md)
+4. [Validate and Select](essay-stage-4-validate.md)
+5. [Design the Essay](essay-stage-5-design.md)
+6. [Draft and Validate](essay-stage-6-draft.md)
+
+The [instrument map](essay-instrument-map.md) is the sole schedule. Canonical
+instrument cards own every substantive operation.
+
+## Entry contract
+
+1. Identify the source Field Log or Logs. Do not change them.
+2. Give the compact map above and explain that the work creates a separate Essay
+   Field Log, uses fresh agents for blind and reader tests, and pauses before
+   each branch that changes the source boundary, research, method, or output.
+3. Ask for permission to create the Essay Field Log. Stop. A request to use the
+   workflow selects `essay`; it is not artifact consent.
+4. After consent, read [field-trip.md](field-trip.md) and
+   [field-log-events.md](field-log-events.md). Initialize a narrow Essay Field
+   Trip through the bundled writer. Record the initiating comment and the
+   workflow selection with their separate exact authorizations.
+5. Register each source Field Log's canonical `field_log.jsonl` as a stable
+   external source. Preserve its generated `field_log.md` path in provenance.
+   Reading a source trip does not join it, resume its workflow, or authorize
+   mutation.
+6. Read [essay-instrument-map.md](essay-instrument-map.md) and
+   [essay-stage-1-frame.md](essay-stage-1-frame.md). Present the Stage 1 opening
+   card and stop before examining the source Field Logs. Once the user starts
+   Stage 1, read those logs in full as the Focus Interview specimen under the
+   read-only source boundary.
+
+If the source belongs to an Expedition, the Essay Field Trip may join that
+Expedition only after separate user consent. Expedition membership is useful
+navigation, not inherited evidence or permission.
+
+## Record and artifact contract
+
+The Essay Field Log replaces `essay_space.md`, per-essay logs, candidate logs,
+and hand-written decision ledgers. Record in it:
+
+- the editorial brief and source boundary;
+- source collection and examination coverage;
+- every instrument lifecycle and bounded reading;
+- candidate IDs, typed source support, validation results, and unresolved gaps;
+- the selected attention and validation policies and every later branch choice;
+- user corrections, design choices, draft-generated questions, and approval;
+- workflow pauses, resumptions, completion gates, failures, and downgrades.
+
+Keep only ordinary working artifacts beside the log:
+
+```text
+probes/                 raw context-isolated samples and exact prompts
+drafts/                 outlines, drafts, and pre-edit snapshots
+sources/                copied transient sources when the writer requires them
+essay.md                the approved essay, when one is produced
+```
+
+Link long traces from instrument readouts. Do not create another special essay
+log or silently make a Markdown artifact authoritative over `field_log.jsonl`.
+
+## Source boundary and return work
+
+The source Field Logs are read-only evidence trails. Record exact examination
+coverage in the Essay Field Log. Preserve each imported item's original claim
+kind and source pointer; promotion into an essay candidate does not upgrade it.
+
+When survey, design, or drafting exposes missing theory, disputed source
+interpretation, or evidence outside the selected research boundary:
+
+1. record the gap as a `return-to` question in the Essay Field Log;
+2. state which candidate or passage depends on it and what the essay must not
+   assume;
+3. pause Essay at the exact stage and artifact;
+4. let the user choose whether to start another Field Trip, resume an existing
+   source trip, narrow the essay, keep the uncertainty visible, or abandon the
+   candidate; and
+5. if new work returns, register that Field Log as another read-only source and
+   resume only after the user chooses the branch.
+
+Essay never writes a return into the originating Field Log by side effect.
+
+## Authority and lifecycle
+
+Workflow selection schedules the declared route. It does not create the Essay
+Field Log, start a stage, widen a source or research boundary, select a
+conditional instrument, cross a return point, choose a candidate, approve a
+draft, or authorize publication.
+
+### Stage-opening and completion cadence
+
+Before every stage:
+
+1. Say `We are at Stage N of 6` and state the stage's bounded aim.
+2. Name the scheduled instruments in ordinary language, the source boundary,
+   any research or fresh-agent work, and the artifacts that will be created.
+3. State what the user will see at the next return point.
+4. Ask whether to start and stop.
+5. After agreement, record `workflow.started` for Stage 1 or
+   `workflow.resumed` for a later stage, including the stage, promised return,
+   and exact user pointer.
+
+At every return point, append the promised readings, run the stage completion
+gate, and record `workflow.paused` before asking the user to choose a branch.
+The next stage does not start merely because the prior gate passed.
+
+For each gate:
+
+1. enumerate the stage's required instruments, operations, outputs, and return;
+2. cite each actual lifecycle, context boundary, control, downgrade, trace, and
+   bounded reading;
+3. mark each observable condition complete or missing;
+4. preserve failures, residue, and unmeasured material; and
+5. proceed only after the human selects the next declared branch.
+
+## Attention and validation policy
+
+Stage 1 asks the user to select an attention policy before candidates exist.
+The recommended policy is: keep unvalidated candidate exhaust in instrument
+readouts, apply the declared validation stack to every candidate that reaches
+it, and show no more than three candidates that remain eligible under the
+selected brief—or report that none remain.
+
+Stage 1 also freezes how gate readings become workflow states. The recommended
+validation policy requires complete applicable gates for eligibility, treats a
+null result as support only for the named absence it tested, permits
+`not applicable` only when a card's triggering premise or minimum input is
+absent, holds incomplete or inconclusive evidence work, returns unresolved
+theory or interpretation, and does not resolve conflicting decision-bearing
+readings by vote or model confidence. Stage 4 records the exact result and
+predeclared rule that bind every state.
+
+When eligible candidates exceed the attention limit, use a predeclared
+non-ranking sample. The recommended rule covers distinct collision groups and
+candidate-map regions in frozen map order, then uses stable candidate IDs. Keep
+the complete eligible set and sampling trace in the Field Log. Surface order is
+not a judgment of worth, novelty, or evidence strength.
+
+This policy protects attention without giving Kit authority to abandon an
+inquiry. A candidate may be recorded as ineligible under the selected gates,
+held for evidence, returned for theory, useful only as orientation, or eligible
+for user choice. The user may inspect the full map, change the policy for a
+later pass, revive a candidate, or stop. Never change the frozen policy during
+validation to preserve a favored candidate.
+
+## Branch contract
+
+| Branch | Observable condition | What it examines or changes | Added work and likely distortion | Rejoin or exit | Human checkpoint |
+| --- | --- | --- | --- | --- | --- |
+| Revise the brief | The user corrects audience, source boundary, success standard, attention policy, or validation policy | Whether the route is solving the intended editorial problem | Re-run only affected framing; early wording may anchor later work | Stage 1 | Stage 1 return |
+| Select candidate bodies (`select-candidate-bodies`) | A completed dialectic contains candidate artifacts not already authorized as sources | Which named bodies enter Stage 2 examination coverage | Reading polished candidates may anchor the survey to prior synthesis | Stage 2 survey | Stage 2 source-inclusion checkpoint before body reading |
+| Run a loss audit (`run-loss-audit`) | A frozen reduction may have erased useful material carried by one source | Which sourced items vanished and which reduction rule dropped them | Separate source scans add work and may rescue material merely because it was omitted | Stage 2 return | Stage 2 conditional-instrument offer |
+| Collect residue (`run-residue-collect`) | A named frame may have dropped sourced material it cannot absorb | What sourced remainder the frame leaves and why | A remainder pass may mistake interest or missing input for residue | Stage 2 return | Stage 2 conditional-instrument offer |
+| Expand the source survey | A named source region remains unexamined and could change coverage | Whether omitted source material contains a distinct signal | More source reading may reward volume or salience | Stage 2 | Stage 2 return |
+| Expand the candidate map | A named source, reader, form, or intervention region is empty | Whether the map missed a candidate family | More generation may create cosmetic variety | Stage 3 | Stage 3 return |
+| Run negative transfer (`run-negative-transfer`) | A candidate uses a cross-domain mapping as argumentative support | Whether the same mapping discriminates on a preselected nearby negative case | Control selection may be self-serving or the negative case may be too distant | Stage 4 before candidate classification | Per-candidate transfer checkpoint |
+| Expand validation research (`expand-validation-research`) | A candidate is held because the bounded prior-art or evidence pass is incomplete | Whether a user-bounded Research Survey or a wider rerun of the affected gate changes its result | Search availability may privilege documented fields; a broad survey may look conclusive | Stage 4, rerunning only affected gates | Stage 4 return |
+| Return for theory or evidence | A candidate depends on a new mechanism, interpretation, synthesis, or out-of-scope fact | The load-bearing gap | Another Field Trip may widen the inquiry or delay the essay | Pause; register returned Field Log as a new source | Any stage return |
+| Develop a candidate | At least one candidate is eligible under the selected policy | How a chosen candidate can become an essay without losing its support | Presentation work can smooth away source-specific value | Stage 5 | Stage 4 return |
+| Choose or revise the outline family | Stage 5 has returned distinct source- and goal-fit organizing logics | Which kind of structure the detailed outlines should use | Family labels may still anchor the user or disguise hybrids | Stage 5 family pass | First Stage 5 return |
+| Choose or revise the outline | The selected family has yielded concrete source-traced outlines | Which section sequence and function should govern the draft | Repeated outlining can polish away resistant material | Stage 5 outline pass | Second Stage 5 return |
+| Choose or revise the packaging | The selected outline has yielded source-checked titles, subtitles, and descriptions | Which public frame should enter the blind outline checkpoint | Packaging may overpromise or steer the apparent argument | Stage 5 packaging pass | Third Stage 5 return |
+| Run outcome ablation (`run-outcome-ablation`) | A design or draft component is claimed to cause one named reader outcome | Whether changing that component changes the named outcome under a matched control | The variant may change several features or miss another useful effect | Stage 5 before the outline probe or Stage 6 final gate | Conditional-control checkpoint in the active stage |
+| Run framing sensitivity (`run-framing-sensitivity`) | Wording, order, or model may change a decision-relevant design or draft reading | Which findings remain stable under controlled variants | Variants may change meaning or correlated models may look independent | Stage 5 before the outline probe or Stage 6 final gate | Conditional-control checkpoint in the active stage |
+| Revise the design | The user rejects or corrects the selected outline's frame, structure, or packaging | Whether another design better preserves the candidate | Repeated packaging can optimize for familiarity | Stage 5 | Final Stage 5 return |
+| Draft the essay | The user approves one evidence-traced design | Whether the approved design works as prose | Drafting may generate unsupported theory or semantic drift | Stage 6 | Stage 5 return |
+| Run draft cartography (`run-draft-cartography`) | The draft materially changes its introduction or public packaging | Expected basins, source-specific residuals, and collapse risk in the changed public frame | Model recurrence may look like public opinion, novelty, or quality | Stage 6 cleanup | Draft-prediction checkpoint before cleanup |
+| Finish with the map | The user wants no draft, or no candidate remains eligible | Preserve the editorial search without forcing prose | None beyond final trace audit | Complete workflow at Stage 4 | Stage 4 return |
+| Approve the draft | The user has read the draft, accepts it, and no load-bearing unsupported marker remains | Final filename and working-note cleanup | Approval is user-fit, not proof of truth | Complete workflow at Stage 6 | Stage 6 return |
+| Publish or share | An approved essay exists | External distribution | Irreversible exposure and publication rights | Separate action outside workflow completion | Post-completion request |
+
+Kit may explain why a branch fits the returned evidence. Kit never chooses a
+conditional branch, changes the attention or validation policy, abandons a
+candidate, or publishes by inference.
+
+A conditional calling signal authorizes only an offer. At the named checkpoint,
+record `workflow.paused` and the proposed branch. A selected branch records the
+exact user pointer and `workflow.resumed` before work begins. A decline records
+a waiver and the unmeasured remainder; it never becomes a null result. After a
+selected operation returns its bounded reading, rejoin only at the table's
+declared point.
+
+## Re-entry
+
+On a later session, validate and inspect the Essay Field Log before reading
+working artifacts. Recover the active workflow ID, lifecycle, stage, promised
+return, selected attention and validation policies, source list and examination
+coverage, instrument states, branch history, open questions, and artifact
+paths. Validate source Field Logs before reading them, but do not resume or
+modify their workflows. Ask only for state that the Essay log does not contain.
+
+## Completion and trace
+
+The workflow completes only when one declared completion branch has run and the
+Field Log contains every scheduled instrument trace, checkpoint, branch choice,
+waiver, unresolved gap, and artifact pointer required by that branch.
+
+## Admission and test
+
+Treat this prototype as a draft workflow. Before raising its status:
+
+1. run it on one real Essay Field Trip with human branch choices;
+2. compare the written route with what happened;
+3. replay it on a contrasting source Field Trip without repairing the route in
+   flight; and
+4. preserve both traces, including a no-essay result or other failure shape;
+5. judge the complete trajectories against every standing behavior in
+   `.agents/behaviors/`, including a positive Stage 5 packaging choice and a
+   negative case where Kit takes that branch without the user's selection; and
+6. repair the owning workflow, runtime, trace, fixture, or judge layer rather
+   than treating a conforming trajectory as evidence of epistemic validity.

--- a/reference/instrument-usage-audit.md
+++ b/reference/instrument-usage-audit.md
@@ -37,12 +37,17 @@ home-domain uses.
 | `behavior-chain`          | 0              | `draft`       |
 | `belief-stress`           | 4              | `trialed`     |
 | `blind-cartography`       | 10             | `practiced`   |
+| `candidate-collision`     | 0              | `draft`       |
 | `candidate-spectrograph`  | 2              | `trialed`     |
 | `criterion-excavation`    | 2              | `trialed`     |
 | `defamiliarize`           | 4              | `trialed`     |
 | `design-grammar`          | 25             | `established` |
 | `donor-perturb`           | 12             | `practiced`   |
 | `elenchus`                | 11             | `practiced`   |
+| `editorial-candidate-map` | 0              | `draft`       |
+| `editorial-design`        | 0              | `draft`       |
+| `editorial-source-survey` | 0              | `draft`       |
+| `evidence-sufficiency`    | 0              | `draft`       |
 | `focus-interview`         | 12             | `practiced`   |
 | `formation-section`       | 7              | `trialed`     |
 | `fracture-scan`           | 12             | `practiced`   |
@@ -53,13 +58,22 @@ home-domain uses.
 | `home-frame-leak`         | 1              | `trialed`     |
 | `hostile-assay`           | 8              | `trialed`     |
 | `loss-audit`              | 27             | `established` |
+| `mechanism-discriminator` | 0              | `draft`       |
 | `negative-transfer`       | 8              | `trialed`     |
 | `neutral-control`         | 5              | `trialed`     |
 | `open-page`               | 0              | `draft`       |
+| `outcome-ablation`        | 0              | `draft`       |
 | `position-preservation`   | 2              | `trialed`     |
+| `prior-art-subtraction`   | 0              | `draft`       |
 | `real-world-check`        | 0              | `draft`       |
+| `reader-assay`            | 0              | `draft`       |
+| `reader-promise`          | 0              | `draft`       |
+| `research-survey`         | 0              | `draft`       |
 | `residue-collect`         | 8              | `trialed`     |
 | `self-distanced-replay`   | 0              | `draft`       |
+| `semantic-drift`          | 0              | `draft`       |
+| `source-bound-drafting`   | 0              | `draft`       |
+| `source-transfer-assay`   | 0              | `draft`       |
 | `stake-map`               | 0              | `draft`       |
 | `structural-recombine`    | 105            | `established` |
 | `substrate-map`           | 9              | `trialed`     |
@@ -70,6 +84,11 @@ home-domain uses.
 
 ## Material qualifications
 
+- The thirteen Essay instruments begin at zero. Older Dialectic Press artifacts
+  shaped their admission and controls, but those workflow outputs do not prove
+  that the new standalone cards completed their own operations.
+- `research-survey` was added after the dated corpus audit with zero completed
+  home-domain uses. Its structural validator tests do not count as uses.
 - `behavior-chain` remains at zero. One prior agent-failure comparison helped
   with card admission, but the shipped card targets human material and that
   trial does not test it. The later synthetic comparator run also does not

--- a/reference/instruments/candidate-collision.md
+++ b/reference/instruments/candidate-collision.md
@@ -1,0 +1,41 @@
+---
+id: candidate-collision
+name: "Candidate Collision Test"
+summary: "Whether essay candidates are distinct, nested, sequential, or duplicates"
+use_when: "Several validated candidates may be alternate phrasings or sections of one essay"
+avoid_when: "Do not use collision to rescue candidates that failed evidence-bearing gates."
+access_target: "Candidate identity under evidence, reader, intervention, and form exchange"
+requires: "At least two frozen candidates with source, mechanism, evidence, and reader-promise traces"
+execution_seat: orchestrator
+fresh_context: optional
+effort: medium
+persistence: "One pairwise comparison pass; preserve relationship results with candidate IDs."
+artifact_risk: "A neat portfolio fragments one argument, or related essays are collapsed merely because they share evidence."
+maturity: draft
+documented_uses: 0
+---
+
+# Candidate Collision Test (`candidate-collision`)
+
+- **Phenomenon sought:** Whether two essay candidates retain distinct editorial spines when their evidence, readers, interventions, forms, and promised effects are exchanged.
+- **Why use it:** Titles and audiences can make one argument look like several. Shared sources can also make genuinely different interventions look redundant.
+- **Operating range:** Use only after candidates pass their own applicable validation. Do not merge, rank, or select inside the result.
+- **Input:** Candidate cards, source traces, prior-art remainders, mechanisms, evidence ledgers, reader promises, and form hypotheses.
+- **What changes:** Controlled exchange removes surface identity cues and tests which relations are load-bearing.
+
+## Procedure
+
+1. Freeze each candidate's claim, causal or narrative spine, evidence, reader promise, intervention, and form.
+2. Exchange evidence. Record whether each candidate still works and what breaks.
+3. Exchange readers and promises. Record whether the intervention remains distinct or becomes translation.
+4. Exchange form and scale. Record whether one candidate becomes a section, example, or short version of the other.
+5. Test whether one shared spine can honestly carry both without losing a validated remainder.
+6. Classify the relationship as likely duplicate, nested section/application, sequence, shared-evidence distinct essay, incompatible framing, or unresolved.
+7. State what evidence or user choice would resolve an unresolved relationship.
+
+- **Result:** Pairwise exchange trace, broken and preserved spines, relationship classifications, combination losses, and unresolved distinctions.
+- **Control:** Use the frozen pre-exchange candidates as baselines. A fresh reader may repeat a close pair without titles, but the orchestrator retains provenance.
+- **Common distortions:** Shared evidence is mistaken for one argument; packaging differences are inflated; a sequence is created for portfolio neatness; or combining hides incompatible readers.
+- **Escalate / stop:** Escalate to user selection for portfolio or form. Stop when every relevant pair has one traced relationship or the set has fewer than two candidates.
+- **What it requires:** Pairwise comparison after hard gates; cost grows with candidate count, so apply only to eligible candidates.
+- **Execution placement:** **Orchestrator.** It needs every candidate's complete validation trace and must preserve IDs through exchanges. A fresh subagent can audit one close pair. Return relationships without merging or selecting.

--- a/reference/instruments/editorial-candidate-map.md
+++ b/reference/instruments/editorial-candidate-map.md
@@ -1,0 +1,41 @@
+---
+id: editorial-candidate-map
+name: "Editorial Candidate Map"
+summary: "A varied, unranked set of essay candidates grounded in frozen source signals"
+use_when: "A source survey supports several possible essays and one headline result would narrow the field"
+avoid_when: "Do not run before the source map and editorial brief are frozen or after expectation samples have contaminated generation."
+access_target: "Source-grounded essay possibilities across distinct editorial coordinates"
+requires: "A corrected source survey, frozen editorial brief, and expectation outputs hidden from every generator"
+execution_seat: hybrid
+fresh_context: preferred
+effort: high
+persistence: "Several generated samples and a frozen map; keep candidate cards and generator traces in a Field Log."
+artifact_risk: "Cosmetic variations masquerade as distinct essays, or weak fragments gain false equality through coverage quotas."
+maturity: draft
+documented_uses: 0
+---
+
+# Editorial Candidate Map (`editorial-candidate-map`)
+
+- **Phenomenon sought:** Structurally distinct essays already supportable by a frozen source survey when source, reader, intervention, form, scale, and method disclosure vary independently.
+- **Why use it:** Sequential ideation converges on the synthesis, first thesis, or preferred audience. Controlled editorial variation exposes alternatives while source trace prevents free invention.
+- **Operating range:** Use after source survey and before expectation-map exposure. Do not use it to rank, validate novelty, repair missing theory, or generate from sparse topic prompts.
+- **Input:** Frozen source-signal register, editorial brief, source statuses, constraints, and named empty regions. Blind expectation outputs and desired winners must remain hidden.
+- **What changes:** The operation rotates editorial coordinates while holding source support fixed. It produces generated samples, not discovered facts.
+
+## Procedure
+
+1. Freeze the candidate grammar: allowed source signals, possible readers, interventions, forms and scales, disclosure levels, and exclusions.
+2. Generate across at least three coordinates. Include smaller pieces, failed moves, unresolved but honest questions, method pieces, and candidates in tension with the author's current view when the source supports them.
+3. Use separate sibling-hidden generators for different coordinate assignments when available. Each sees only the frozen brief, allowed source signals, and its assignment—not expectation probes, sibling candidates, rankings, or desired results.
+4. Give every candidate a stable ID and record: public question or claim; source signal and exact support; intervention; reader promise hypothesis; form and scale; theory and evidence gaps; source status; injected choices; risks; and related candidates.
+5. Reject samples that lack a named source signal, depend on new theory, or differ only in wording. Preserve the rejection reason as a generated-sample control, not a validation verdict.
+6. Cluster relationships without ranking: competing accounts, different scales, possible sequence, shared evidence, or likely duplicate.
+7. Freeze the map before any blind expectation output reaches the orchestrator.
+
+- **Result:** Frozen candidate cards, coordinate coverage, generation traces, relationship clusters, rejected prompt-only samples, injected choices, and empty regions. Every candidate remains unvalidated.
+- **Control:** Source pointers and frozen brief constrain generation. Sibling-hidden contexts reduce convergence. A reconstruction check must show that each card can be rebuilt from allowed source signals without new theory.
+- **Common distortions:** Coverage quotas inflate weak candidates; audience changes look like new claims; polish hides sameness; generators import remembered expectation basins; or inferred source signals are presented as evidence.
+- **Escalate / stop:** Escalate to `blind-cartography` only after the freeze. Offer another run only for a user-selected empty coordinate. Stop when additional samples differ only in phrasing or unsupported ambition.
+- **What it requires:** Usually several fresh generators plus orchestration. A small map may be orchestrator-only but must be labeled correlated.
+- **Execution placement:** **Hybrid.** The orchestrator freezes source support, assignments, and candidate IDs. Fresh sibling-hidden generators produce samples; the orchestrator performs only source reconstruction and relationship clustering. Without fresh contexts, return a correlated provisional map and do not claim broad coverage.

--- a/reference/instruments/editorial-design.md
+++ b/reference/instruments/editorial-design.md
@@ -1,0 +1,43 @@
+---
+id: editorial-design
+name: "Editorial Design Assay"
+summary: "Source- and goal-fit outline families, detailed structures, and packaging options with their losses"
+use_when: "A validated essay candidate needs a reader-facing design without changing its theory"
+avoid_when: "Do not use to invent a missing mechanism, analogy, concept, evidence base, or synthesis."
+access_target: "Which outline logics the source and reader goal can sustain, and what each presentation choice preserves or hides"
+requires: "One validated candidate with source topology, evidence, prior-art, and a user-confirmed reader goal"
+execution_seat: hybrid
+fresh_context: preferred
+effort: high
+persistence: "Several design samples and at least three user choices; keep every option, choice, and loss in the Field Log."
+artifact_risk: "Fluent packaging changes the claim, centers an expected groove, or makes a familiar structure look inevitable."
+maturity: draft
+documented_uses: 0
+---
+
+# Editorial Design Assay (`editorial-design`)
+
+- **Phenomenon sought:** Which organizing logics and reader-facing arrangements can transmit a validated candidate while preserving its source support, remainder, uncertainty, and limits.
+- **Why use it:** One candidate can support several kinds of outline. A dense episode, a long formation, a set of parallel cases, and a distributed conceptual record should not all collapse into the same claim-example-objection template. Drafting the first fluent arrangement hides what presentation added, lost, or normalized.
+- **Operating range:** Use after candidate selection and before prose. Presentation may choose among established frames and vocabulary; it may not repair theory.
+- **Input:** Frozen candidate claim, source ledger and topology, prior-art remainder, mechanism and evidence, reader goal and promise, expected basins, known risks, editorial constraints, and either an open or user-selected outline family.
+- **What changes:** The assay first varies the organizing logic, then—only after the user chooses—generates controlled designs within that choice. It changes frame, vocabulary, sequence, examples, disclosure level, and packaging while keeping the candidate and source boundary fixed.
+
+## Procedure
+
+1. Restate the candidate in plain language without analogy, coined terms, title, or preferred structure. Freeze this as the presentation baseline.
+2. Inventory only frames, terms, examples, and models already supported by the source or authorized supporting evidence. Record the source topology and the change the reader should undergo in the user's terms.
+3. When no outline family has been selected, generate two to four genuinely different organizing logics supported by that source-goal pair. Possible forms include episode-led, chronological formation, braided threads, comparison, question-led explanation, claim-and-counterclaim, mechanism-led exposition, or a mosaic of particulars; this is an open set, not a menu to fill. For each family, show the load-bearing source shape, intended reader movement, material it foregrounds, material it strands, and chief risk. Do not write section headings, choose a family, or blend families by default. Return this family map and stop.
+4. After the user chooses, revises, or combines a family, freeze that exact choice. Generate two or three concrete outlines within it, unless the user asks for one. Each outline must differ in the sequence or function of sections, not merely in wording. Name each section's question, source material, necessary mechanism or example, transition, approximate scale, disclosure level, and contribution to the reader promise.
+5. Return the concrete outlines with their losses and stop. The user chooses, revises, combines, or rejects them. Do not infer approval from a preference for the family.
+6. After one outline is approved, generate packaging: several title families, subtitles, and descriptions. Label every item generated and keep packaging subordinate to the approved structure.
+7. For each family, outline, and packaging option, compare claim, confidence, causal relation, scope, source role, expected-basin overlap, and source-specific remainder with the plain baseline.
+8. Record material hidden, distorted, or made newly salient. Put resistant source material in a misfit register rather than forcing it into the arc.
+9. Return the current pass's options and losses without recommendation unless the user separately requests one, then stop for the user's choice.
+
+- **Result:** Depending on the selected pass: an unranked source-and-goal-fit outline-family map; concrete outlines within the user's chosen family; or packaging for an approved outline. Preserve the plain baseline, section-level source trace, expected-basin exposure, losses, misfits, and return questions across passes.
+- **Control:** Plain-language baseline and source reconstruction. A design fails this assay when it requires a new theoretical link or cannot reproduce the validated remainder.
+- **Common distortions:** The model defaults to a five-part argument regardless of the source; the most vivid episode dictates the whole form; chronology becomes causality; “different” families differ only in labels; a hybrid absorbs every option without a clear organizing rule; titles overpromise; analogy becomes mechanism; source complexity is polished away; or detailed outlines appear before the user chooses a family.
+- **Escalate / stop:** Offer `outcome-ablation` for a claimed load-bearing component, `framing-sensitivity` for decision-relevant wording or order, or a return question for missing theory. Stop when no design preserves the candidate.
+- **What it requires:** Deep design work, at least three user checkpoints, and optional fresh generators. Keep every family, outline, packaging option, choice, loss, and comparison trace.
+- **Execution placement:** **Hybrid.** The orchestrator freezes the candidate and runs preservation checks. Fresh sibling-hidden generators may draft distinct designs from the same baseline. Without fresh contexts, return correlated options and name convergence risk.

--- a/reference/instruments/editorial-source-survey.md
+++ b/reference/instruments/editorial-source-survey.md
@@ -1,0 +1,41 @@
+---
+id: editorial-source-survey
+name: "Editorial Source Survey"
+summary: "Traceable source signals, source topology, editorial seams, shadows, particulars, and gaps without essay generation"
+use_when: "Completed inquiry material may contain several essays or useful source regions beyond its headline result"
+avoid_when: "Do not use to repair theory, judge novelty, or generate and rank essay candidates."
+access_target: "Source-grounded editorial signals, their provenance, usable scale, source topology, and unresolved gaps"
+requires: "One frozen source boundary with at least one inspectable Field Log or structured inquiry record"
+execution_seat: orchestrator
+fresh_context: optional
+effort: high
+persistence: "A full source pass; use a Field Log to preserve coverage, source pointers, and typed signals."
+artifact_risk: "Vivid passages or neglected material look valuable merely because they are salient or omitted."
+maturity: draft
+documented_uses: 0
+---
+
+# Editorial Source Survey (`editorial-source-survey`)
+
+- **Phenomenon sought:** Source material whose completed conceptual or factual work could support editorial use at a stated scale, including seams, supporting shadows, concrete particulars, unresolved gaps, and the shapes in which evidence actually survives.
+- **Why use it:** A polished conclusion narrows attention. A provenance-first survey shows what the full inquiry established, relegated, left unresolved, or never examined before candidate generation fixes the field.
+- **Operating range:** Use on completed Field Logs, research records, debates, dialectics, notebooks, or other structured corpora. Do not infer public value, novelty, or the essay to write.
+- **Input:** Freeze included Field Logs, entries, readouts, sources, artifacts, and exclusions. Preserve each item's original claim kind and user-recorded status.
+- **What changes:** The survey reads the corpus through four declared lenses—completed seams, supporting shadows, source particulars, and gaps—and describes how evidence is distributed, without producing titles, theses, candidates, outlines, or rankings.
+
+## Procedure
+
+1. Validate the source records and list exact coverage before interpretation.
+2. Read the inquiry's generative or failure analysis before polished candidate outputs when the source has that distinction. For a dialectic, read determinate negation before candidate essays.
+3. Register source signals with exact pointer, claim kind, confidence, user status, and the largest honest editorial scale they could support: sentence, section, short piece, or full essay.
+4. Mark **seams** where hard explanatory work is already complete; **shadows** where a headline result reduced strong material to support; **particulars** whose mechanisms, examples, or sequences reward close reading; and **gaps** that require evidence, interpretation, or theory.
+5. Describe the source topology without turning it into an outline: dense episodes, long sequences, parallel cases, distributed concepts, mechanism chains, recurring motifs, fragments, or another evidenced shape. Record mixed shapes and where each one breaks. These are descriptive labels, not a choice of story form.
+6. Separate omitted material from unsupported material. Omission is not value.
+7. Return theoretical gaps, evidence gaps, rejected source material, and unexamined regions separately. Do not repair or promote them.
+
+- **Result:** Source coverage; typed signal register; seams, shadows, particulars, and gaps with pointers; source topology and its breakpoints; largest honest scale; contraindicated uses; and unmeasured regions.
+- **Control:** Preserve exact source coverage and claim kinds. Compare each signal with the source's own conclusion so neglect is not mistaken for contradiction or value. A fresh source-only reader may audit coverage, but the orchestrator owns the final trace.
+- **Common distortions:** Quotability substitutes for support; forgotten material receives a novelty bonus; a large corpus produces a falsely large opportunity space; familiar labels force mixed evidence into one topology; or the survey smuggles in candidate theses or outlines.
+- **Escalate / stop:** Offer `loss-audit` when a frozen reduction may have erased single-source material, `residue-collect` when a named frame may have dropped sourced material, or a return question when the source lacks load-bearing work. Stop when new reading would only repeat covered regions.
+- **What it requires:** Deep source reading and exact provenance. Keep the full trace in a Field Log.
+- **Execution placement:** **Orchestrator.** It needs the editorial brief, source statuses, Field Log lineage, and live user corrections. A fresh subagent may extract a bounded source region with no candidate brief, but the orchestrator must preserve coverage and claim kinds. Without traceable sources, stop. Return the survey without candidate generation or selection.

--- a/reference/instruments/evidence-sufficiency.md
+++ b/reference/instruments/evidence-sufficiency.md
@@ -1,0 +1,41 @@
+---
+id: evidence-sufficiency
+name: "Evidence Sufficiency Assay"
+summary: "Load-bearing claims matched to evidence, confidence, scale, and missing support"
+use_when: "A candidate's claim may exceed the evidence available in its source inquiry"
+avoid_when: "Do not turn absence of documentary evidence into evidence of absence or erase clearly labeled testimony."
+access_target: "Claim-by-claim support, scale fit, adverse evidence, unknowns, and research gaps"
+requires: "A frozen candidate and traceable source ledger"
+execution_seat: orchestrator
+fresh_context: optional
+effort: medium
+persistence: "One claim ledger per candidate; preserve it through design and drafting."
+artifact_risk: "Evidence volume substitutes for relevance, or easy-to-cite sources crowd out testimony and local knowledge."
+maturity: draft
+documented_uses: 0
+---
+
+# Evidence Sufficiency Assay (`evidence-sufficiency`)
+
+- **Phenomenon sought:** Whether available evidence supports each load-bearing claim at the scope and confidence the candidate needs.
+- **Why use it:** A sourced essay can still overreach when evidence supports only an example, lower scale, different population, or weaker confidence.
+- **Operating range:** Use on any candidate whose reader promise depends on factual, interpretive, experiential, or causal support. Do not demand the same evidence kind from every essay form.
+- **Input:** Candidate claims, source ledger with claim kinds, prior-art and mechanism results when present, intended scope, and research boundary.
+- **What changes:** The assay decomposes the candidate into claims and aligns each with supporting, adverse, missing, and out-of-scope material.
+
+## Procedure
+
+1. List every load-bearing claim and the exact confidence and scale the draft would need.
+2. Attach supporting evidence with source pointer, kind, coverage, and relevance.
+3. Attach adverse or complicating evidence separately. User agreement and model fluency are not world evidence.
+4. Mark evidence that is authentic but indirect, illustrative, at another scale, or dependent on disputed interpretation.
+5. Record `unknown` when evidence is missing. Do not use zero, silence, or a proxy as failure.
+6. State the largest honest claim the current ledger can support and the exact research that could change it.
+7. Reconstruct the candidate using only supported claims; list what disappears.
+
+- **Result:** Claim-evidence ledger, confidence and scale audit, adverse evidence, unknowns, largest honest claim, reconstruction loss, and bounded research gaps.
+- **Control:** Source kinds and scope remain unchanged. Reconstruction from supported claims tests whether the candidate's spine survives without unsupported bridges.
+- **Common distortions:** Citation count becomes strength; testimony becomes observation; missing data becomes a negative result; or the claim narrows only in footnotes.
+- **Escalate / stop:** Hold for research when a named attainable source could close a load-bearing gap. Return for theory when evidence cannot supply a missing explanatory relation. Stop when the supported claim is clear.
+- **What it requires:** Exact source trace and claim decomposition; fresh evidence retrieval is a separate authorized branch.
+- **Execution placement:** **Orchestrator.** Continuity across source kinds, mechanism, scope, and user corrections is essential. A fresh agent may audit a bounded claim ledger. If source pointers are absent, stop with an untraceable-candidate result.

--- a/reference/instruments/mechanism-discriminator.md
+++ b/reference/instruments/mechanism-discriminator.md
@@ -1,0 +1,41 @@
+---
+id: mechanism-discriminator
+name: "Mechanism Discriminator"
+summary: "The candidate's explanatory sequence and the observation that separates it from nearby accounts"
+use_when: "An essay candidate claims to explain why or how something happens"
+avoid_when: "Do not force causal machinery onto documentary, literary, personal, or purely interpretive work."
+access_target: "Explanatory sequence, nearest alternative, distinguishing evidence, scale match, and weakening observation"
+requires: "One frozen candidate, its claimed explanatory scope, and available evidence"
+execution_seat: orchestrator
+fresh_context: optional
+effort: medium
+persistence: "One analytical pass; preserve with the candidate's validation trace."
+artifact_risk: "A plausible story is mistaken for a mechanism, or causal standards dismiss a candidate with another honest function."
+maturity: draft
+documented_uses: 0
+---
+
+# Mechanism Discriminator (`mechanism-discriminator`)
+
+- **Phenomenon sought:** Whether a candidate supplies an explanatory sequence that available evidence can distinguish from its nearest credible alternative.
+- **Why use it:** Stakes, correlations, and fluent narratives often look explanatory. A discriminator makes the links, scale, and possible defeater explicit.
+- **Operating range:** Use only when the reader promise includes explanation, causation, or prediction. For other essay functions, return `not applicable` with the declared function.
+- **Input:** Candidate claim, source support, intended scale, nearest known alternative, and evidence boundary.
+- **What changes:** The operation converts a whole claim into ordered links and forces a comparison with a competing account.
+
+## Procedure
+
+1. State the phenomenon and explanatory scope without rhetorical stakes.
+2. Write the proposed sequence as actors or parts, conditions, operations, intermediate changes, and outcome.
+3. Give every link a source pointer and claim kind. Mark unsupported links.
+4. State the nearest credible alternative at equal strength and scale.
+5. Identify evidence both accounts predict, evidence that discriminates, and evidence at the wrong scale.
+6. Name one observation or counterexample that would weaken the candidate and one that would weaken the alternative.
+7. Return a mechanism result only when the distinguishing path is supported; otherwise return description, hypothesis, or unresolved competition.
+
+- **Result:** Proposed sequence, support by link, nearest alternative, shared and distinguishing evidence, scale audit, weakening observations, and result kind.
+- **Control:** Equal-strength alternative and link-level source trace. A fresh skeptic may challenge the selected alternative, but later judgment remains separate.
+- **Common distortions:** Sequence is inferred from chronology; one vivid case carries a population claim; alternatives are made weak; or missing links are smoothed by prose.
+- **Escalate / stop:** Escalate to research for a named distinguishing observation or return for theory when the central link must be invented. Stop when the candidate's function is not explanatory.
+- **What it requires:** One careful analytical pass and enough source detail to trace links.
+- **Execution placement:** **Orchestrator.** It must hold candidate scope, source kinds, prior-art result, and user-corrected function together. A fresh agent may audit one link or alternative. Without a credible alternative or link support, return the gap rather than a mechanism verdict.

--- a/reference/instruments/outcome-ablation.md
+++ b/reference/instruments/outcome-ablation.md
@@ -1,0 +1,41 @@
+---
+id: outcome-ablation
+name: "Outcome-Specific Ablation"
+summary: "The observed effect of removing one component against a frozen control"
+use_when: "An analogy, term, example, section, hook, or other component is claimed to cause a named reader outcome"
+avoid_when: "Do not infer that a component is useless merely because one tested outcome survives its removal."
+access_target: "Controlled difference in one named outcome after one component changes"
+requires: "A control artifact, one removable component, a named outcome, and matched evaluator prompts"
+execution_seat: parallel-subagents
+fresh_context: required
+effort: medium
+persistence: "One control and variant per outcome; preserve exact texts, prompts, and responses."
+artifact_risk: "The variant changes several things, the evaluator guesses the preferred result, or a weak test reports no effect."
+maturity: draft
+documented_uses: 0
+---
+
+# Outcome-Specific Ablation (`outcome-ablation`)
+
+- **Phenomenon sought:** Whether changing or removing one editorial component changes one named reader outcome under a matched comparison.
+- **Why use it:** Survival after removal does not show that a component is decorative; it may serve another function. Naming the outcome before the edit makes the causal claim testable.
+- **Operating range:** Use for comprehension, transfer, recall, credibility, mechanism recognition, stakes, causal continuity, density, or reproducibility. Do not use to invent or repair theory.
+- **Input:** Frozen control, one component, one outcome, matched variant, evaluator population or profile, and identical question.
+- **What changes:** One component is removed or replaced while the target outcome and all other material remain fixed.
+
+## Procedure
+
+1. Name the claimed outcome and how the response will show it before editing.
+2. Preserve the exact control artifact.
+3. Produce one variant that changes only the selected component. Record unavoidable collateral changes.
+4. Give control and variant to separate fresh evaluators with the same neutral question. Hide the preferred result and sibling response.
+5. Compare observed answers against the named outcome, not general preference.
+6. Record claimed-outcome decline, no detected change, alternate-outcome change, evaluator disagreement, and test sensitivity limits separately.
+7. Do not decide to keep or cut the component inside the reading.
+
+- **Result:** Control and variant pointers, named outcome, matched prompts, evaluator responses, controlled difference, collateral changes, alternate explanations, and sensitivity limits.
+- **Control:** Frozen original, one-variable edit, matched question, sibling-hidden fresh evaluators, and exact trace. Fresh contexts remain model-correlated.
+- **Common distortions:** Several edits travel together; placeholder removal damages readability; evaluator style preference replaces the outcome; or no detected difference becomes proof of redundancy.
+- **Escalate / stop:** Repeat only when the first test lacked sensitivity or the user selects another outcome. Return a theory gap rather than editing around it. Stop after the selected outcome has a legible comparison.
+- **What it requires:** At least two fresh contexts or external readers per comparison. Decision-bearing claims benefit from replicated pairs.
+- **Execution placement:** **Parallel subagents required for an agent assay.** Each evaluator sees one version and the same question, never the sibling or desired answer. External human readers provide a stronger world-fit control when available. Without separated evaluators, downgrade to an author comparison and do not call it controlled ablation.

--- a/reference/instruments/prior-art-subtraction.md
+++ b/reference/instruments/prior-art-subtraction.md
@@ -1,0 +1,41 @@
+---
+id: prior-art-subtraction
+name: "Prior-Art Subtraction"
+summary: "The candidate remainder after the nearest established arguments are removed"
+use_when: "A candidate may be a familiar argument in new language or attached to a valued source"
+avoid_when: "Do not infer novelty from model recall, search absence, or unfamiliar wording."
+access_target: "Closest prior art, supplied overlap, and the candidate's supported remainder"
+requires: "One frozen public candidate, its source trace, and a bounded research scope"
+execution_seat: hybrid
+fresh_context: preferred
+effort: high
+persistence: "A bounded research and comparison pass; preserve citations, search scope, and subtraction trace."
+artifact_risk: "Documented traditions crowd out tacit knowledge, or the analyst redescribes overlap to preserve a favored remainder."
+maturity: draft
+documented_uses: 0
+---
+
+# Prior-Art Subtraction (`prior-art-subtraction`)
+
+- **Phenomenon sought:** What, if anything, remains of a candidate after the nearest established arguments, concepts, and standard treatments supply their real contribution.
+- **Why use it:** A new label, audience, example, or cherished source can make a familiar argument feel new. Direct subtraction exposes the supported remainder without treating search as a novelty oracle.
+- **Operating range:** Use for selection, publication, or claims of fresh contribution. Do not require novelty when the selected brief explicitly permits a useful explainer; classify that result separately.
+- **Input:** Frozen candidate wording, source support, intended reader delta, research boundary, and search authorization.
+- **What changes:** A separated research pass retrieves nearby work without the desired remainder, then comparison rewrites and subtracts overlap.
+
+## Procedure
+
+1. Freeze the candidate and the claim kinds it inherits from its source.
+2. Give a fresh researcher the public claim, domain, and bounded search task, but not the desired novelty, author's motive, atlas position, or preferred survival.
+3. Identify three to five closest established arguments when evidence supports them. Record citations, scope, and uncertainty; model recall supplies search leads only.
+4. Restate the candidate in each prior account's own vocabulary and strongest form.
+5. Subtract every claim, mechanism, example family, and conclusion the prior art already supplies.
+6. State the remainder in one sentence, then trace each part to independent source support. Mark a new label, illustration, audience translation, or unsupported analogy as no substantive remainder under a novelty brief.
+7. Record unsearched regions and traditions that search availability may have suppressed.
+
+- **Result:** Closest prior art, search scope, candidate restatements, overlap ledger, supported remainder or null result, confidence limits, and unsearched regions.
+- **Control:** Separate retrieval from desired survival. Require citations before a selection-bearing verdict. Reconstruct the original candidate from overlap plus remainder to test subtraction completeness.
+- **Common distortions:** Search prominence becomes intellectual importance; exact phrase absence becomes novelty; distant work is chosen to manufacture a remainder; or local and experiential knowledge disappears.
+- **Escalate / stop:** Hold the candidate when required research is incomplete. Stop with a null remainder when only packaging remains. A theoretical remainder still needs mechanism and evidence tests.
+- **What it requires:** Bounded outside research and careful comparison; keep the full trace with any selection it affects.
+- **Execution placement:** **Hybrid.** A fresh researcher retrieves and states prior art without the desired result. The orchestrator compares it with the frozen candidate and source trace. If fresh research is unavailable, run a sighted lower-confidence scan and do not claim a selection-bearing novelty result.

--- a/reference/instruments/reader-assay.md
+++ b/reference/instruments/reader-assay.md
@@ -1,0 +1,40 @@
+---
+id: reader-assay
+name: "Reader Assay"
+summary: "Fresh-reader claims, confusion, memory, and usable change after encountering a draft"
+use_when: "A draft needs a separated test of what readers actually recover rather than what the author intended"
+avoid_when: "Do not treat model readers as a population sample or substitute them for a specialized human audience."
+access_target: "Reader reconstruction, confusion, memorable particulars, usable delta, and genericity signals"
+requires: "A frozen draft, target reader description, neutral questions, and separated readers"
+execution_seat: parallel-subagents
+fresh_context: required
+effort: medium
+persistence: "Several reader responses plus exact prompts; preserve with the tested draft version."
+artifact_risk: "Prompted readers echo the intended answer, shared model lineage looks like consensus, or a profile becomes stereotype."
+maturity: draft
+documented_uses: 0
+---
+
+# Reader Assay (`reader-assay`)
+
+- **Phenomenon sought:** What separated readers reconstruct, fail to understand, retain, and say they could newly distinguish or attempt after reading one frozen draft.
+- **Why use it:** Authors and informed editors see intended structure. Fresh readers expose transmission failures and unintended readings.
+- **Operating range:** Use on a complete draft or bounded section. Model readers yield generated response samples; human readers provide stronger audience evidence.
+- **Input:** Frozen artifact version, target reader description grounded in the brief, neutral question set, and at least two separated readers; use three or more for a decision-bearing pattern.
+- **What changes:** Readers encounter the draft without the author's thesis, validation history, expected answer, or sibling responses.
+
+## Procedure
+
+1. Freeze the exact draft and reader description. Remove intended-answer cues from the task prompt.
+2. Give each reader the same artifact and ask: what it claims; where it confuses or fails to convince; what detail or distinction remains; what they can now notice, explain, decide, or attempt; and what feels generic or predictable.
+3. Keep responses sibling-hidden and record reader type, context, model when known, and exact prompt.
+4. Compare stable recoveries, disagreements, omissions, false reconstructions, and profile-sensitive responses.
+5. Trace each response to the draft. Mark unsupported reader inference rather than treating it as text content.
+6. Compare observed responses with the earlier `reader-promise` without scoring the essay or choosing revisions.
+
+- **Result:** Individual responses, stable and divergent reconstructions, confusion points, memorable particulars, observed usable deltas, genericity signals, source locations, and audience limits.
+- **Control:** Frozen draft, neutral prompt, separated readers, sibling blindness, and exact response trace. Report same-model correlation and sample limits.
+- **Common distortions:** Leading questions manufacture success; model agreement becomes audience consensus; profiles encode stereotypes; or one articulate response outweighs others.
+- **Escalate / stop:** Escalate to actual target readers when publication stakes or domain expertise matter. Offer `framing-sensitivity` when wording or order appears causal. Stop when the selected sample and limitations are recorded.
+- **What it requires:** Two to five fresh contexts or external readers. More samples do not create statistical calibration.
+- **Execution placement:** **Parallel subagents required for an agent assay.** Each sees only the frozen draft, reader setting, and neutral questions. The orchestrator collates without rewriting or deciding. Without fresh contexts, return an author self-check under another name.

--- a/reference/instruments/reader-promise.md
+++ b/reference/instruments/reader-promise.md
@@ -1,0 +1,41 @@
+---
+id: reader-promise
+name: "Reader Promise Assay"
+summary: "The concrete change an evidence-backed essay could make for a named reader"
+use_when: "A candidate has a topic or claim but its value to a particular reader remains vague"
+avoid_when: "Do not reduce literary, contemplative, or personal value to immediate utility."
+access_target: "Reader prior, evidence-mediated change, usable distinction, and promise limits"
+requires: "One candidate, intended reader or reader uncertainty, mechanism and evidence results, and essay function"
+execution_seat: orchestrator
+fresh_context: optional
+effort: low
+persistence: "One short reading per candidate; preserve through design and reader testing."
+artifact_risk: "A fictional reader validates the author's preference, or usefulness crowds out other legitimate effects."
+maturity: draft
+documented_uses: 0
+---
+
+# Reader Promise Assay (`reader-promise`)
+
+- **Phenomenon sought:** The specific difference an evidence-backed candidate may make to what a named reader can notice, distinguish, explain, decide, attempt, remember, or feel.
+- **Why use it:** Topic importance and author motive do not establish reader value. A before/evidence/after trace makes the promise testable without pretending every essay is advice.
+- **Operating range:** Use after mechanism and evidence are visible. The essay function may be explanatory, documentary, interpretive, practical, personal, literary, or mixed.
+- **Input:** Candidate, intended reader or declared reader uncertainty, current reader prior, evidence and mechanism results, and proposed essay function.
+- **What changes:** The assay binds a possible reader change to specific evidence and form rather than general stakes.
+
+## Procedure
+
+1. State the reader and setting without demographic stereotype. Mark unknowns.
+2. State what that reader likely already knows or notices, with support or explicit hypothesis labeling.
+3. Name the evidence, mechanism, sequence, or felt form the essay would provide.
+4. Complete: `Before, this reader ...; through ...; afterward they may ...`.
+5. Test whether the afterward state is only a new label, awareness claim, or summary of familiar concern.
+6. State what close reading supplies beyond a short summary and which reader would not receive the same value.
+7. Return several distinct promises when the candidate honestly serves several functions; do not choose among them.
+
+- **Result:** Reader and setting, prior hypothesis, evidence-mediated change, close-reading delta, limits, alternate legitimate promises, and unmeasured reader response.
+- **Control:** Trace the promise to mechanism and evidence. Later `reader-assay` tests generated or human response; this card predicts no actual response.
+- **Common distortions:** Imagined readers become stereotypes; author enthusiasm becomes reader need; new vocabulary is called transformation; or immediate action is privileged over reflection.
+- **Escalate / stop:** Escalate to actual reader research or `reader-assay` when the promise affects publication or design. Stop when the brief accepts orientation and no stronger delta is supported.
+- **What it requires:** A short analytical pass and, when possible, user correction of the reader description.
+- **Execution placement:** **Orchestrator.** It needs the brief, candidate, evidence, and user knowledge of readers. A fresh subagent may challenge a frozen reader prior but cannot establish a population response. Return promises without selecting the audience.

--- a/reference/instruments/research-survey.md
+++ b/reference/instruments/research-survey.md
@@ -1,0 +1,98 @@
+---
+id: research-survey
+name: "Research Survey"
+summary: "A source-traced evidence landscape, with disputes, coverage limits, and a portable Markdown record."
+use_when: "A broad initial survey is needed before closer analysis or another instrument can work well."
+avoid_when: "Do not use for one fact, an exhaustive systematic review, or a request to decide, rank, or recommend."
+access_target: "The current searchable evidence landscape, its major positions and conflicts, and the gaps left by the search."
+requires: "A research question, intended downstream use, scope boundaries, source access, and a writable Markdown destination."
+execution_seat: either
+fresh_context: optional
+effort: variable
+persistence: "Always writes one portable Markdown survey; offer a Field Log when the inquiry also needs a continuing source and decision record."
+artifact_risk: "Search rank and model priors can masquerade as consensus, while a polished survey can make partial coverage look final."
+maturity: draft
+documented_uses: 0
+---
+
+# Research Survey (`research-survey`)
+
+- **Phenomenon sought:** The current searchable shape of evidence around a bounded question: useful terms, major positions and mechanisms, material conflicts, representative cases, source trails, and coverage gaps.
+- **Why use it:** Model memory gives fast orientation but hides provenance, age, and coverage. Ad hoc browsing often follows prominence and stops after finding a plausible answer. This instrument produces a source-traced substrate that another person or instrument can inspect without the original conversation.
+- **Operating range:** Use for broad initial orientation, unfamiliar or changing domains, or inquiries whose later instruments need a shared factual substrate. It may organize sources into traceable topics and unranked positions because that organization is part of its reading. It may not decide which position is right, infer prevalence from search results, recommend an action, or claim a systematic or exhaustive review. For medical, legal, financial, safety, or other high-stakes questions, label the survey as orientation and do not treat it as the evidence review required for action. Use a direct lookup for one stable fact and a domain review method when formal inclusion criteria, quality scoring, or effect estimates are required.
+- **Input:** A working research question; the intended downstream use; topical, temporal, geographic, and source-language boundaries where they matter; supplied starting sources; a chosen depth; and a writable destination. Read supplied sources first. Ask one Focus question only when a missing boundary would materially change the survey. Otherwise use `broad` as the default depth.
+- **What changes:** Search and selection make published, indexed, accessible material easier to see than tacit, private, local, failed, untranslated, or unpublished material. The survey's headings and coverage frame also impose categories that later work may mistake for the field itself.
+
+## Depth
+
+- **Quick:** Establish enough source-traced terms, positions, disputes, and gaps to orient the next operation. Use one compact search and one contrary-evidence pass.
+- **Broad (default):** Search each result-changing part of the coverage frame, revisit weak cells, and stop on the saturation rule below.
+- **Deep:** Use separate source tracks for distinct domains, positions, periods, or source languages when access permits. Freeze each track's notes before integration and retain its limits. Shared model lineage and shared search indexes remain correlated even when agents are separated.
+
+Depth changes effort and coverage, not the authority boundary or the kind of result.
+
+## Procedure
+
+1. **Freeze the survey brief.** Record the exact question, intended downstream use, depth, boundaries, starting sources, research date, source cutoff, available source languages, and output path. State exclusions. Do not silently widen the question when adjacent material looks useful.
+2. **Build a coverage frame.** Before searching, name the result-changing cells that deserve a pass. Use only dimensions relevant to the question, such as foundational and current work; primary, scholarly, practitioner, and critical sources; major positions; mechanisms; jurisdictions; affected groups; successful and failed cases; or claimed and measured outcomes. The frame guides coverage and remains revisable; it is not a claim that the field naturally has those parts.
+3. **Search adaptively.** Use the available research harness, web search, databases, supplied corpora, or targeted research agents. Let the executor choose effective queries and order. Record the main search routes, indexes, date limits, and access failures rather than narrating every click. Open and inspect a source before using it; search snippets and model recollection are leads, not support.
+4. **Extract typed claims.** For each material claim, preserve what kind of support it has: primary record, scholarly finding, source author's argument, practitioner report, user-supplied material, or model inference. Record source, date, evidence basis, relevant scope, and material limits. One citation does not support a broader claim than the source makes.
+5. **Run the source controls.** Prefer primary records for actions, rules, dates, original arguments, and measured results. Use authoritative syntheses to orient a field, then inspect load-bearing original work when accessible. Diversify publishers, institutions, source types, and dates where the question warrants it. Mark paywalls, inaccessible sources, language limits, and citation chains that could not be checked.
+6. **Run the prominence and conflict controls.** Search for contrary findings, failed cases, minority or critical positions, alternate local terms, and non-prominent sources. Reverse important claim language and search outside the dominant publisher or institution cluster. Preserve conflicts with their differing populations, measures, periods, assumptions, and evidence quality. Absence of a found conflict is a bounded search result, not evidence of consensus.
+7. **Audit coverage and saturation.** Mark each coverage cell as supported, thin, conflicting, inaccessible, or unsearched. Spend the final pass on thin cells that could change later work. For a broad or deep run, stop when two consecutive targeted passes add no material position, mechanism, conflict, source class, or boundary condition, or when the declared budget or access limit is reached. A quick run stops after its compact contrary-evidence pass. Record which stop condition fired and what remains unmeasured.
+8. **Write the portable record.** Copy and complete [`assets/research-survey-template.md`](../../assets/research-survey-template.md). Use direct source links and stable source IDs. Keep descriptive organization separate from later interpretation. The handoff index may point consumers to relevant sections; it must not select, rank, or run another instrument.
+9. **Check the artifact.** Every material factual claim needs support or an explicit inference label. Every source ID in the claim ledger must resolve. The file must retain disputes, coverage status, controls run, source-access limits, the stop rule, the chief artifact risk, and the unmeasured remainder. When Node is available, run `node scripts/validate-research-survey.js <survey.md>` from the skill root. The validator checks structure and references, not truth, source quality, or semantic neutrality.
+
+## Result
+
+Return the Markdown path plus a concise bounded reading:
+
+- the scope and depth actually completed;
+- the source-traced topics, positions, mechanisms, and conflicts made available;
+- the coverage and saturation result;
+- the chief way search or the survey frame may have distorted the landscape; and
+- the important remainder that was not measured.
+
+Do not paste the full survey into chat when the file is accessible. Do not append a conclusion, ranking, recommendation, or proposed synthesis. A later explicit request may use the saved survey for those tasks.
+
+## Controls
+
+- **Scope lock:** Freeze question, intended use, boundaries, exclusions, depth, and output path before research.
+- **Source floor:** Inspect sources directly and prefer the closest available evidence for each claim.
+- **Claim trace:** Link every material claim to a stable source ID or label it as inference or hypothesis.
+- **Source diversity:** Check publisher, institution, source type, date, language, and constituency concentration where material.
+- **Prominence control:** Search beyond top-ranked, famous, English-language, and highly cited material.
+- **Conflict control:** Seek and preserve contrary findings, failed cases, minority positions, and alternate terms.
+- **Recency control:** Separate foundational sources from current evidence and state the source cutoff.
+- **Coverage control:** Report supported, thin, conflicting, inaccessible, and unsearched cells instead of implying uniform coverage.
+- **Saturation control:** Record the stop rule and the last material additions; never equate saturation within sampled routes with completeness.
+- **Interpretation boundary:** Organize the evidence landscape but do not adjudicate, rank, recommend, or infer social prevalence from retrieval frequency.
+- **Portability control:** Save one self-contained Markdown file with its brief, claims, sources, controls, limits, and handoff index.
+
+## Common distortions
+
+- Search prominence, citation count, or model familiarity is reported as importance or consensus.
+- English-language, published, institutional, successful, or easily indexed material stands in for the whole domain.
+- A review or news story launders a claim whose original source says less.
+- Several sources repeat one underlying source and appear to be independent support.
+- Old foundational material and current conditions are blended.
+- Positions are made cleaner and more coherent than their sources.
+- The coverage frame hardens into an ontology and hides material that crosses its cells.
+- Collection volume substitutes for coverage, source quality, or a clear stopping rule.
+- A polished orientation turns into an unauthorized conclusion or recommendation.
+- The Markdown file looks complete enough that later instruments forget its exclusions and unmeasured remainder.
+
+## Escalate and stop
+
+Use a formal evidence-review method instead when the user needs exhaustive retrieval, reproducible inclusion and exclusion, study-quality appraisal, or quantitative synthesis. Stop or return a clearly labeled `bounded` survey when source access, language, time, or safety requirements prevent a defensible landscape. Without browsable or supplied sources, downgrade to a **memory map** and do not call it a Research Survey; label every item as model recollection and return no source-grounded coverage or saturation claim.
+
+After a complete run, return the file and bounded reading, then stop. Do not auto-run a handoff instrument or interpret what the survey means.
+
+## Execution placement
+
+- **Execution seat:** **Either.** The orchestrator, a capable research harness, or a research subagent may perform the search. The orchestrator owns the frozen brief and final artifact when several tracks are used.
+- **Context boundary:** Every executor receives the same frozen question, intended use, scope, claim-typing rules, and output contract. Deep tracks may be separated by source class, position, period, jurisdiction, or language and remain blind to sibling findings until their notes are frozen. No executor receives a desired conclusion.
+- **Placement rationale:** Freshness is not required for ordinary source retrieval. Separate tracks can improve coverage and preserve conflict, but they do not make shared model families or search indexes independent.
+- **Fallback:** One executor may complete any depth honestly within the declared budget. If parallel work, source access, or a writable destination fails, reduce depth or return a `bounded` artifact with the failed cells and residue. Without inspected sources, use the memory-map downgrade above.
+- **Return path:** Executors return source-traced notes or paths. The orchestrator checks the controls, writes and validates the portable Markdown file, and returns only the bounded survey readout.
+- **What it requires:** Source access, enough time for the chosen depth, a writable destination, and closer source inspection for every load-bearing claim. A quick run may fit one conversation; broad and deep runs should usually use a saved file and may warrant a Field Log when the inquiry will continue.

--- a/reference/instruments/semantic-drift.md
+++ b/reference/instruments/semantic-drift.md
@@ -1,0 +1,40 @@
+---
+id: semantic-drift
+name: "Semantic Drift Assay"
+summary: "Meaning changes between a frozen draft and its edited version"
+use_when: "Cleanup or revision may have changed claims, confidence, causality, scope, attribution, or reader promise"
+avoid_when: "Do not call spelling, formatting, or clearly mechanical corrections semantic changes."
+access_target: "Substantive before-and-after changes and the edit that introduced each one"
+requires: "A frozen pre-edit snapshot, edited version, and declared meaning invariants"
+execution_seat: either
+fresh_context: preferred
+effort: medium
+persistence: "One comparison per material edit pass; keep the snapshot and change ledger."
+artifact_risk: "Surface similarity hides a changed claim, or a noisy diff makes harmless edits look substantive."
+maturity: draft
+documented_uses: 0
+---
+
+# Semantic Drift Assay (`semantic-drift`)
+
+- **Phenomenon sought:** Changes in meaning introduced between a frozen artifact and an edited version, especially changes to claim, confidence, causal relation, scope, attribution, and reader promise.
+- **Why use it:** Cleaner prose can become less exact. Line diffs expose changed words but do not classify what those changes did to the argument.
+- **Operating range:** Use after cleanup, structural revision, or validation edits. It compares versions; it does not judge which meaning is preferable.
+- **Input:** Frozen control, edited version, source ledger or approved design, and declared invariants.
+- **What changes:** The assay aligns meaning-bearing units across versions and classifies substantive deltas separately from mechanics.
+
+## Procedure
+
+1. Freeze file hashes or immutable paths for control and edited versions.
+2. Produce a mechanical diff and group edits into meaning-bearing units rather than isolated tokens.
+3. Classify each non-mechanical delta: claim, confidence, causality, scope, attribution, evidence role, reader promise, structure, example function, or unresolved.
+4. State before, after, triggering edit, source/design support, and whether the change was authorized.
+5. Test reconstruction: can the edited version still reproduce the approved claim, evidence boundaries, and named uncertainty without consulting the control?
+6. Record restored, accepted, flagged, and unresolved changes without applying a preferred repair.
+
+- **Result:** Version pointers, mechanical diff, substantive change ledger, reconstruction result, unauthorized or unsupported changes, and unresolved comparisons.
+- **Control:** Immutable pre-edit snapshot, declared invariants, and source or design trace. A fresh auditor can reduce author capture.
+- **Common distortions:** Every paraphrase becomes drift; summary-level comparison misses local causality; later rationale rewrites the original intent; or the auditor silently restores its preferred prose.
+- **Escalate / stop:** Return to design or validation when a load-bearing invariant changed. Ask the user about intentional changes. Stop when each substantive delta has a disposition.
+- **What it requires:** Two stable versions and a bounded semantic comparison; no outside research unless a source attribution itself is disputed.
+- **Execution placement:** **Either; fresh auditor preferred.** A fresh context sees both versions, invariants, and source trace but not the desired verdict. The orchestrator may run it when exact drafting history matters, while naming self-review risk. Return the ledger without editing either version.

--- a/reference/instruments/source-bound-drafting.md
+++ b/reference/instruments/source-bound-drafting.md
@@ -1,0 +1,42 @@
+---
+id: source-bound-drafting
+name: "Source-Bound Drafting"
+summary: "A prose draft constrained by an approved design, frozen sources, and an explicit research boundary"
+use_when: "An approved evidence-traced design needs to become prose without silently adding theory or support"
+avoid_when: "Do not use to discover the essay, repair a weak candidate, invent a mechanism, or fill an evidence gap."
+access_target: "What the approved design becomes in prose, what fails to carry, and which unsupported additions drafting solicits"
+requires: "One approved design, frozen source ledger, voice constraints, reader goal, and draft research boundary"
+execution_seat: orchestrator
+fresh_context: none
+effort: high
+persistence: "A draft, source trace, and question register; keep all three with the approved design in the Field Log."
+artifact_risk: "Fluent prose hides unsupported theory, turns transitions into causal claims, or makes generated examples look sourced."
+maturity: draft
+documented_uses: 0
+---
+
+# Source-Bound Drafting (`source-bound-drafting`)
+
+- **Phenomenon sought:** How an approved, source-supported editorial design survives prose, where it breaks under exposition, and what unsupported additions prose generation invites.
+- **Why use it:** A sound outline does not guarantee a sound draft. Transitions, examples, emphasis, and compression can change a claim or smuggle in missing theory. This operation makes the prose transformation and its new gaps traceable.
+- **Operating range:** Use only after the user approves one design. It may realize supported choices and improve exposition; it may not expand the source boundary, repair theory, or treat fluency as support.
+- **Input:** Approved candidate and design, section-level source trace, frozen source ledger, reader goal and promise, voice constraints, known risks and misfits, and an explicit research boundary.
+- **What changes:** The operation changes an approved design into continuous prose. It chooses wording, pacing, transitions, and supported examples while holding the candidate, source roles, confidence, and theoretical boundary fixed.
+
+## Procedure
+
+1. Freeze the approved design, source ledger, voice constraints, reader goal, and research boundary. Give the draft a version identifier.
+2. For each planned section, restate its question, supported claim, source material, mechanism or example, confidence, transition function, and contribution to the reader promise.
+3. Draft each section from only that packet and the authorized sources. Preserve uncertainty, attribution, source roles, and material resistance. Do not smooth a misfit into agreement.
+4. Use an example only when its source and argumentative role are recorded. Mark illustrative wording as generated; do not present it as observed evidence.
+5. Test each transition for the relation it asserts. When a transition needs a new causal link, distinction, mechanism, analogy, counter-position, interpretation, or synthesis, record a return question instead of drafting the link as settled.
+6. Mark every unsupported addition at the point where it appears. A supporting fact may enter only after verification within the research boundary. New theory may not enter this draft.
+7. Complete one source-trace pass. Map each load-bearing claim to its source and claim kind; list untraced claims, missing bridges, stranded material, and sections that do not carry their assigned work.
+8. Save the initial draft and a separate pre-edit snapshot. Return both with the source trace and draft-generated question register. Do not silently revise beyond the bounded transformation.
+
+- **Result:** A versioned source-bound draft, pre-edit snapshot, section and claim trace, generated-example labels, unsupported-addition register, stranded material, and return questions.
+- **Control:** Reconstruct each section against the frozen design and source ledger. A claim fails the control when its meaning, confidence, causal relation, scope, or source role cannot be reproduced from those inputs.
+- **Common distortions:** A polished bridge becomes a causal mechanism; an analogy becomes evidence; a generated example gains false provenance; voice constraints overstate confidence; a vivid source displaces the approved structure; or the draft quietly solves a question the workflow returned.
+- **Escalate / stop:** Return to validation or design when prose exposes a load-bearing gap. Return for theory when the draft requires new interpretation or synthesis. Stop when the source boundary cannot support the approved design. Do not broaden research or revise the candidate without the user's branch choice.
+- **What it requires:** Sustained drafting attention, exact source access, versioned files, and a Field Log that preserves the approved design, source trace, gaps, and return questions.
+- **Execution placement:** **Orchestrator.** The drafting seat may see the approved Essay history, frozen sources, and user constraints, but no material outside the research boundary. Continuity is needed to preserve the user's exact choices. A fresh drafter may prepare a labeled sample, but without the choice history it is a downgrade; the orchestrator must run the reconstruction control and return the bounded result to the user.

--- a/reference/instruments/source-transfer-assay.md
+++ b/reference/instruments/source-transfer-assay.md
@@ -1,0 +1,42 @@
+---
+id: source-transfer-assay
+name: "Source and Transfer Assay"
+summary: "Whether a source warrants the role and cross-domain use assigned to it"
+use_when: "A source, tradition, law, science, theology, or donor domain carries part of an essay's argument"
+avoid_when: "Do not impose an argumentative transfer test on an explicitly literary juxtaposition that claims no inference."
+access_target: "Source authenticity, interpretation, role, transfer warrant, target evidence, and category-error risk"
+requires: "One source claim, one target claim, and the proposed relation between them"
+execution_seat: either
+fresh_context: preferred
+effort: high
+persistence: "One source and mapping audit; preserve citations and role classifications with the claim."
+artifact_risk: "A resonant analogy supplies the inference, or strict evidentiary rules erase legitimate literary use."
+maturity: draft
+documented_uses: 0
+---
+
+# Source and Transfer Assay (`source-transfer-assay`)
+
+- **Phenomenon sought:** Whether a cited source supports the exact role an argument assigns it, especially when relations cross domains.
+- **Why use it:** Authentic quotation and thematic resemblance do not establish interpretation, relevance, structural warrant, or target-domain truth. Separating those layers exposes category errors and legitimate limited uses.
+- **Operating range:** Use when a source provides evidence, mechanism, analogy, vocabulary, authority, or illustration. Apply the transfer burden only to relations doing argumentative work.
+- **Input:** Exact source passage or finding, source context, target-domain claim, proposed mapping, and claimed role.
+- **What changes:** The assay decomposes one fluent citation into independently testable source and transfer claims.
+
+## Procedure
+
+1. Verify source identity, authenticity, scope, and the source's actual subject.
+2. State the source's claim in context and distinguish quotation, interpretation, inference, and tradition-specific authority.
+3. State the target claim without donor vocabulary.
+4. Classify the source role: evidence, mechanism, analogy, vocabulary, authority within a bounded tradition, illustration, or literary juxtaposition.
+5. Name the exact relation transferred and the structural warrant for preserving it.
+6. Identify independent target-domain evidence. Do not let the source or analogy establish the target claim by itself.
+7. Record category changes, governing-subject changes, omitted disanalogies, and a nearby case where the proposed relation may not travel.
+8. When transfer carries the argument, require a separately selected `negative-transfer` run before calling the boundary tested.
+
+- **Result:** Source-context account, role classification, target claim, transferred relation, warrant, independent evidence, category risks, and untested negative case.
+- **Control:** Restate the target claim without donor language; if its inference disappears, the transfer is carrying unsupported work. Source citations and independent target evidence remain separate baselines.
+- **Common distortions:** Reverence, expertise, or vividness substitutes for warrant; illustration becomes mechanism; source interpretation changes to fit the target; or literary value is rejected for lacking causal force it never claimed.
+- **Escalate / stop:** Escalate to `negative-transfer` for an argumentative mapping or to another Field Trip for disputed interpretation. Stop when the source can only illustrate or when the claimed relation has no target evidence.
+- **What it requires:** Source access, contextual reading, and target-domain evidence proportionate to the claim.
+- **Execution placement:** **Either; fresh auditor preferred for material stakes.** The auditor sees the source, target, and claimed role but not the author's preferred survival. The orchestrator may run it when continuity matters, while naming capture risk. Without source context, stop rather than infer warrant.

--- a/scripts/validate-research-survey.js
+++ b/scripts/validate-research-survey.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REQUIRED_FRONTMATTER = [
+  "instrument",
+  "title",
+  "question",
+  "scope",
+  "intended_use",
+  "depth",
+  "researched_at",
+  "source_cutoff",
+  "status",
+];
+
+const REQUIRED_SECTIONS = [
+  "Survey brief",
+  "Orientation",
+  "Terms and distinctions",
+  "Evidence landscape",
+  "Positions and mechanisms",
+  "Disputes and conflicting evidence",
+  "Cases and timeline",
+  "Coverage and gaps",
+  "Claim-to-source ledger",
+  "Sources",
+  "Search and control record",
+  "Limits and unmeasured",
+  "Handoff index",
+];
+
+const REQUIRED_CONTROLS = [
+  "Search routes",
+  "Prominence counter-search",
+  "Contrary-evidence search",
+  "Source-class coverage",
+  "Recency check",
+  "Saturation check",
+];
+
+const FORBIDDEN_SECTIONS = [
+  "conclusion",
+  "conclusions",
+  "recommendation",
+  "recommendations",
+  "ranking",
+  "best option",
+  "final answer",
+];
+
+function usage() {
+  return "Usage: node scripts/validate-research-survey.js <survey.md>";
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseFrontmatter(source, errors) {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    errors.push("missing YAML frontmatter");
+    return {};
+  }
+
+  const result = {};
+  for (const [index, line] of match[1].split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    const field = line.match(/^([a-z][a-z0-9_]*):\s*(.*)$/);
+    if (!field) {
+      errors.push(`frontmatter line ${index + 2} is not a flat key/value field`);
+      continue;
+    }
+    result[field[1]] = unquote(field[2]);
+  }
+  return result;
+}
+
+function collectSections(source) {
+  const lines = source.split(/\r?\n/);
+  const sections = new Map();
+  let active;
+
+  for (const line of lines) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      active = heading[1];
+      sections.set(active, []);
+      continue;
+    }
+    if (active) sections.get(active).push(line);
+  }
+
+  return new Map(
+    [...sections].map(([heading, body]) => [heading, body.join("\n").trim()]),
+  );
+}
+
+function controlValue(section, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = section.match(
+    new RegExp(`^- \\*\\*${escaped}:\\*\\*\\s*(.+?)\\s*$`, "mi"),
+  );
+  return match?.[1]?.trim() ?? "";
+}
+
+function isMissing(value) {
+  return (
+    !value ||
+    /\{\{[^}]+\}\}|YYYY-MM-DD/i.test(value) ||
+    /^(?:tbd|todo|unknown|none|n\/a|not run)(?:\b|\s|[-—:]|$)/i.test(value)
+  );
+}
+
+function validate(source) {
+  const errors = [];
+  const metadata = parseFrontmatter(source, errors);
+
+  for (const field of REQUIRED_FRONTMATTER) {
+    if (isMissing(metadata[field])) errors.push(`frontmatter field ${field} is missing`);
+  }
+
+  if (metadata.instrument && metadata.instrument !== "research-survey") {
+    errors.push('frontmatter field instrument must be "research-survey"');
+  }
+  if (metadata.depth && !["quick", "broad", "deep"].includes(metadata.depth)) {
+    errors.push("frontmatter field depth must be quick, broad, or deep");
+  }
+  if (
+    metadata.status &&
+    !["complete", "bounded", "stopped"].includes(metadata.status)
+  ) {
+    errors.push("frontmatter field status must be complete, bounded, or stopped");
+  }
+
+  if (/\{\{[^}]+\}\}|YYYY-MM-DD/.test(source)) {
+    errors.push("unresolved template placeholders remain");
+  }
+
+  const sections = collectSections(source);
+  for (const heading of REQUIRED_SECTIONS) {
+    const body = sections.get(heading);
+    if (!body) errors.push(`required section "${heading}" is missing or empty`);
+  }
+
+  for (const heading of sections.keys()) {
+    if (FORBIDDEN_SECTIONS.includes(heading.trim().toLowerCase())) {
+      errors.push(`section "${heading}" crosses the survey's interpretation boundary`);
+    }
+  }
+
+  const controlSection = sections.get("Search and control record") ?? "";
+  for (const label of REQUIRED_CONTROLS) {
+    const value = controlValue(controlSection, label);
+    if (!value) errors.push(`control record "${label}" is missing`);
+    else if (metadata.status === "complete" && isMissing(value)) {
+      errors.push(`complete survey did not run control "${label}"`);
+    }
+  }
+
+  const declaredSources = new Set(
+    [...source.matchAll(/<a\s+id=["']s(\d+)["']><\/a>\s*\*\*S\1\*\*/gi)].map(
+      (match) => `S${match[1]}`,
+    ),
+  );
+  const referencedSources = new Set(
+    [...source.matchAll(/\bS(\d+)\b/g)].map((match) => `S${match[1]}`),
+  );
+  for (const sourceId of referencedSources) {
+    if (!declaredSources.has(sourceId)) {
+      errors.push(`source reference ${sourceId} has no declaration in Sources`);
+    }
+  }
+  if (metadata.status === "complete" && declaredSources.size === 0) {
+    errors.push("complete survey declares no sources");
+  }
+
+  const claimLedger = sections.get("Claim-to-source ledger") ?? "";
+  if (!/\|\s*C\d+\s*\|/.test(claimLedger)) {
+    errors.push("claim-to-source ledger contains no claim rows");
+  }
+  for (const row of claimLedger.split(/\r?\n/)) {
+    if (!/^\|\s*C\d+\s*\|/.test(row)) continue;
+    if (!/\bS\d+\b/.test(row) && !/\b(?:inference|hypothesis)\b/i.test(row)) {
+      errors.push(`claim ledger row lacks source support or an inference label: ${row}`);
+    }
+  }
+
+  const disputes = sections.get("Disputes and conflicting evidence") ?? "";
+  if (
+    disputes &&
+    !/\b(?:S\d+|no material conflict was found)\b/i.test(disputes)
+  ) {
+    errors.push(
+      "disputes section must cite source IDs or state the bounded no-conflict result",
+    );
+  }
+
+  return errors;
+}
+
+function main(argv) {
+  if (argv.length !== 1 || argv[0] === "--help" || argv[0] === "-h") {
+    const stream = argv.length === 1 ? process.stdout : process.stderr;
+    stream.write(`${usage()}\n`);
+    return argv.length === 1 ? 0 : 2;
+  }
+
+  const file = path.resolve(argv[0]);
+  let source;
+  try {
+    source = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    return 2;
+  }
+
+  const errors = validate(source);
+  if (errors.length) {
+    for (const error of errors) process.stderr.write(`- ${error}\n`);
+    return 1;
+  }
+
+  process.stdout.write(`${file}: valid research survey structure\n`);
+  return 0;
+}
+
+if (require.main === module) process.exitCode = main(process.argv.slice(2));
+
+module.exports = { validate };

--- a/scripts/validate-research-survey.test.js
+++ b/scripts/validate-research-survey.test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const { validate } = require("./validate-research-survey.js");
+
+const template = fs.readFileSync(
+  path.resolve(__dirname, "..", "assets", "research-survey-template.md"),
+  "utf8",
+);
+
+function completeSurvey() {
+  return template
+    .replace(/\{\{[^}]+\}\}/g, "Filled with inspected, source-traced material")
+    .replace(/YYYY-MM-DD/g, "2026-08-24");
+}
+
+test("accepts a complete survey with controls and resolved source links", () => {
+  assert.deepEqual(validate(completeSurvey()), []);
+});
+
+test("rejects a broken claim-to-source trail", () => {
+  const survey = completeSurvey().replace("| S1 |", "| S99 |");
+  assert.ok(
+    validate(survey).some((error) =>
+      error.includes("source reference S99 has no declaration"),
+    ),
+  );
+});
+
+test("rejects a complete survey that skipped the prominence control", () => {
+  const survey = completeSurvey().replace(
+    /- \*\*Prominence counter-search:\*\* .+/,
+    "- **Prominence counter-search:** not run",
+  );
+  assert.ok(
+    validate(survey).some((error) =>
+      error.includes('did not run control "Prominence counter-search"'),
+    ),
+  );
+});
+
+test("rejects conclusion-shaped sections", () => {
+  const survey = `${completeSurvey()}\n## Recommendations\n\nChoose the first option.\n`;
+  assert.ok(
+    validate(survey).some((error) =>
+      error.includes("crosses the survey's interpretation boundary"),
+    ),
+  );
+});


### PR DESCRIPTION
## Summary

Adds **Essay**, a six-stage Field Lab workflow that turns completed Field Logs into source-grounded essay candidates, designs, and drafts. Each run gets its own Field Log, treats originating logs as read-only sources, and leaves candidate choice, workflow branches, draft approval, and publication with the user.

## Approach

- Defines one workflow contract for framing, source survey, candidate mapping, validation and selection, editorial design, and source-bound drafting.
- Makes the instrument map the sole schedule, while stage files own local order, artifacts, returns, and completion gates.
- Adds thirteen editorial instruments for source survey, candidate generation, validation, design, drafting, and reader/drift checks.
- Reuses the general Research Survey instrument when validation needs a broad evidence landscape, with a portable template and structural validator.
- Extends the conformance model with record-scoped consent, stage pause/resume state, attention policy, and unranked candidate presentation.
- Adds positive and negative Essay trajectories plus static contract tests for schedule, instrument-card, and branch alignment.

## Key invariants

- Selecting Essay does not authorize creation of its Field Log. Record consent is separate and names the writable record.
- Originating Field Logs remain read-only. Return questions go into the Essay Field Log, never back into source logs by side effect.
- Every stage pauses at its declared return point. The next stage or conditional branch needs an explicit user choice and persisted resume.
- Candidate validation covers the frozen map. The attention limit changes presentation, not eligibility, and overflow uses a declared non-ranking rule.
- Blind Cartography reports expectedness, residuals, and collapse risk. It cannot rank, clear, fail, or eliminate a candidate.
- Drafting may realize an approved design but may not invent missing theory or support. Every load-bearing gap must be verified, narrowed, removed, or shown as uncertainty before approval.
- Workflow completion does not authorize publication or sharing.

## Non-goals

- This does not rank candidates or add an automatic elimination step.
- It does not create special essay logs, per-candidate logs, or an `essay_space.md`; the Essay Field Log is authoritative.
- It does not replace formal evidence reviews with Research Survey.
- It does not claim the new workflow or instruments are established. They remain draft until real and contrasting field traces support admission.
- It does not publish an approved essay.

## Trade-offs

The workflow has more explicit checkpoints and files than the former standalone press flow. That cost makes authority, source boundaries, conditional controls, and return paths inspectable; the central instrument map and static contract tests limit schedule drift.

Fresh agents reduce anchoring for candidate, blind, reader, and ablation passes, but shared model lineage remains correlated. The contracts preserve that limit instead of treating model agreement as world evidence or audience consensus.

## Verification

From `artifact-browser/`:

```bash
pnpm exec vitest run src/field-lab/conformance --maxWorkers=2
pnpm typecheck
pnpm exec vite build
```

Results: 5 conformance test files passed and 1 was skipped; 41 tests passed and 4 were skipped. Typecheck and the client, SSR, and prerender builds passed.

From the skill root:

```bash
node --test scripts/render-frame.test.js scripts/validate-research-survey.test.js
node scripts/find-instruments.js broad source traced evidence landscape
git diff --check
```

Results: 10 Node tests passed; instrument search parsed and found `research-survey`; the diff check passed. The skill quick validator also reported `Skill is valid!`, and all non-example local Markdown links resolved.

## Files changed

- `README.md` documents Essay and Research Survey for users.
- `SKILL.md` registers Essay, its authority and record rules, and the new instrument cards.
- `reference/essay-workflow.md` defines entry, source boundaries, artifacts, stage lifecycle, attention and validation policy, branch authority, re-entry, and completion.
- `reference/essay-instrument-map.md` is the sole six-stage instrument schedule.
- `reference/essay-stage-1-frame.md` through `reference/essay-stage-6-draft.md` define each stage's local inputs, order, artifacts, return, branches, and gate.
- `reference/instruments/editorial-source-survey.md`, `editorial-candidate-map.md`, `prior-art-subtraction.md`, `source-transfer-assay.md`, `mechanism-discriminator.md`, `evidence-sufficiency.md`, `reader-promise.md`, and `candidate-collision.md` cover editorial discovery and validation.
- `reference/instruments/editorial-design.md`, `outcome-ablation.md`, `reader-assay.md`, `semantic-drift.md`, and `source-bound-drafting.md` cover design, drafting, and draft validation.
- `reference/instruments/research-survey.md` and `assets/research-survey-template.md` add the reusable, source-traced research landscape instrument and artifact.
- `scripts/validate-research-survey.js` and `scripts/validate-research-survey.test.js` check survey structure, controls, source references, and interpretation boundaries.
- `reference/instrument-usage-audit.md` admits the new draft instruments at zero documented uses.
- `artifact-browser/src/field-lab/conformance/model.ts` and `adapters.ts` model and parse Essay-specific authority and presentation events.
- `artifact-browser/src/field-lab/conformance/trajectory-fixtures.ts` and `trajectory.test.ts` cover consent, source immutability, pause/resume, conditional rejoin, attention overflow, packaging choice, and drafting routes.
- `artifact-browser/src/field-lab/conformance/essay-contract.test.ts` prevents workflow schedule, instrument-card, and branch drift.
